### PR TITLE
Add ApplicationInfo defaults to ReleaseBuilder

### DIFF
--- a/src/DotnetPackaging.Deployment/Core/ApplicationInfo.cs
+++ b/src/DotnetPackaging.Deployment/Core/ApplicationInfo.cs
@@ -1,0 +1,8 @@
+namespace DotnetPackaging.Deployment.Core;
+
+public class ApplicationInfo
+{
+    public string PackageName { get; init; } = string.Empty;
+    public string AppId { get; init; } = string.Empty;
+    public string AppName { get; init; } = string.Empty;
+}

--- a/src/DotnetPackaging.Deployment/Core/ReleaseConfiguration.cs
+++ b/src/DotnetPackaging.Deployment/Core/ReleaseConfiguration.cs
@@ -3,6 +3,7 @@ namespace DotnetPackaging.Deployment.Core;
 public class ReleaseConfiguration
 {
     public string Version { get; internal set; } = string.Empty;
+    public ApplicationInfo ApplicationInfo { get; internal set; } = new();
     public TargetPlatform Platforms { get; internal set; } = TargetPlatform.None;
 
     // Platform-specific configurations with their own project paths

--- a/src/DotnetPackaging.Deployment/Deployer.cs
+++ b/src/DotnetPackaging.Deployment/Deployer.cs
@@ -79,7 +79,8 @@ public class Deployer(Context context, Packager packager, Publisher publisher)
     public Task<Result> CreateGitHubReleaseForAvalonia(string avaloniaSolutionPath, string version, string packageName, string appId, string appName, GitHubRepositoryConfig repositoryConfig, ReleaseData releaseData, AndroidDeployment.DeploymentOptions? androidOptions = null)
     {
         var releaseConfig = CreateRelease()
-            .ForAvaloniaProjectsFromSolution(avaloniaSolutionPath, version, packageName, appId, appName, androidOptions)
+            .WithApplicationInfo(packageName, appId, appName)
+            .ForAvaloniaProjectsFromSolution(avaloniaSolutionPath, version, androidOptions)
             .Build();
 
         return CreateGitHubRelease(releaseConfig, repositoryConfig, releaseData);

--- a/test/DotnetPackaging.Deployment.Tests/Integration/PackagingTests.cs
+++ b/test/DotnetPackaging.Deployment.Tests/Integration/PackagingTests.cs
@@ -136,8 +136,9 @@ public class PackagingTests(ITestOutputHelper outputHelper)
 
         var releaseBuilder = deployer.CreateRelease()
             .WithVersion("1.0.0")
-            .ForWindows(DesktopProject, "TestApp")
-            .ForLinux(DesktopProject, "com.superjmn.testapp", "Test App", "TestApp")
+            .WithApplicationInfo("TestApp", "com.superjmn.testapp", "Test App")
+            .ForWindows(DesktopProject)
+            .ForLinux(DesktopProject)
             .ForAndroid(AndroidProject, androidOptions)
             .ForWebAssembly(WasmProject);
         
@@ -185,13 +186,13 @@ public class PackagingTests(ITestOutputHelper outputHelper)
 
         // Test the automatic project discovery method
         var result = await deployer.CreateGitHubReleaseForAvalonia(
-            SolutionPath, 
-            "1.0.0", 
-            "TestApp", 
-            "com.superjmn.testapp", 
-            "Test App", 
-            gitHubRepositoryConfig, 
-            releaseData, 
+            SolutionPath,
+            "1.0.0",
+            "TestApp",
+            "com.superjmn.testapp",
+            "Test App",
+            gitHubRepositoryConfig,
+            releaseData,
             androidOptions);
         
         result.Should().Succeed();


### PR DESCRIPTION
## Summary
- reduce repetition when creating releases by introducing `ApplicationInfo`
- `ReleaseBuilder` now has `WithApplicationInfo` and platform methods that use it
- update `CreateGitHubReleaseForAvalonia` to use the new API
- adjust integration tests for the new fluent API

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b48d54a0832f9cf9ff5101d811cd