### PR TITLE
Use deployment tool in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,8 @@ variables:
   - group: api-keys
   - name: Agent.Source.Git.ShallowFetchDepth
     value: 0
+  - name: ProjectNamePrefix
+    value: ''
 
 steps:
   - checkout: self
@@ -24,9 +26,7 @@ steps:
   - script: dotnet build src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -c Release
     displayName: Build DeployerTool
 
-
   - script: >-
       dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj --
-      nuget --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj
-      --version $(Build.BuildNumber) --api-key $(NuGetApiKey)
-    displayName: Publish DeployerTool
+      nuget --solution DotnetPackaging.sln --version $(Build.BuildNumber) --api-key $(NuGetApiKey) --name-prefix $(ProjectNamePrefix)
+    displayName: Publish Packages


### PR DESCRIPTION
## Summary
- add project prefix variable to pipeline
- run dotnetdeployer to publish packages
- allow `dotnetdeployer` to filter projects by name prefix
- skip projects under Git submodules during discovery

## Testing
- `dotnet build src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -c Release`
- ❌ `dotnet run --no-build -c Release --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- nuget --solution DotnetPackaging.sln --version 1.0.0 --api-key dummy --name-prefix DotnetPackaging` (failed to run due to missing runtime)


------
https://chatgpt.com/codex/tasks/task_e_687e018a4394832f9885797198e62549