### PR TITLE
Add GitVersion fallback

### DIFF
--- a/src/DotnetPackaging/BuildUtils.cs
+++ b/src/DotnetPackaging/BuildUtils.cs
@@ -14,7 +14,9 @@ public static class BuildUtils
     {
         var icon = await GetIcon(setup, directory).TapError(Log.Warning);
         var package = setup.Package.Or(setup.Name).GetValueOrDefault(exec.Name.Replace(".Desktop", ""));
-        var version = setup.Version.GetValueOrDefault("1.0.0");
+        var versionResult = await setup.Version
+            .Match(v => Task.FromResult(Result.Success(v)), GitVersionRunner.Run);
+        var version = versionResult.GetValueOrDefault("1.0.0");
         var name = setup.Name.GetValueOrDefault(directory.Name);
         
         var packageMetadata = new PackageMetadata(name, architecture, isTerminal, package, version)


### PR DESCRIPTION
## Summary
- add `GitVersionRunner` helper for version discovery
- use `GitVersionRunner` in metadata builder when no version is provided

## Testing
- `dotnet build src/DotnetPackaging/DotnetPackaging.csproj -c Release /p:UseLocalZafiroReferences=false`
- `dotnet test test/DotnetPackaging.Deb.Tests/DotnetPackaging.Deb.Tests.csproj -c Release /p:UseLocalZafiroReferences=false` *(fails: NU1008)*

------
https://chatgpt.com/codex/tasks/task_e_687f4e968130832fb2748a23f18c71c5