### PR TITLE
Fix NuGet package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,7 @@
     </PackageVersion>
     <PackageVersion Include="System.IO.Hashing" Version="9.0.5" />
     <PackageVersion Include="DeflateBlockCompressor" Version="0.0.13" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.8.0" />
     <PackageVersion Include="Zafiro" Version="$(ZafiroVersion)" />
     <PackageVersion Include="Zafiro.FileSystem" Version="$(ZafiroVersion)" />
     <PackageVersion Include="Zafiro.FileSystem.Unix" Version="$(ZafiroVersion)" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,5 +24,5 @@ steps:
         args="--name-pattern $(ProjectNamePattern)"
       fi
       dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- \
-        nuget --solution DotnetPackaging.sln --version $(Build.BuildNumber) --api-key $(NuGetApiKey) $args
+        nuget --solution DotnetPackaging.sln --api-key $(NuGetApiKey) $args
     displayName: Publish Packages

--- a/src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj
+++ b/src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="System.CommandLine" />
+    <PackageReference Include="NuGet.Versioning" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotnetPackaging.Deployment\DotnetPackaging.Deployment.csproj" />


### PR DESCRIPTION
## Summary
- use GitVersion inside DeployerTool when version is missing
- validate generated version with NuGet.Versioning
- remove version argument from pipeline
- add NuGet.Versioning package

## Testing
- `dotnet build src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -c Release`
- `dotnet test --verbosity normal -c Release` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb7771464832fa7847b5c73e0736b