### PR TITLE
Fix GitVersion resolution in DeployerTool

### DIFF
--- a/src/DotnetPackaging/GitVersionRunner.cs
+++ b/src/DotnetPackaging/GitVersionRunner.cs
@@ -7,6 +7,60 @@ public static class GitVersionRunner
 {
     public static async Task<Result<string>> Run()
     {
+        if (!GitVersionExists())
+        {
+            var installResult = await Install();
+            if (installResult.IsFailure)
+            {
+                return Result.Failure<string>(installResult.Error);
+            }
+        }
+
+        return await Execute();
+    }
+
+    private static bool GitVersionExists()
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var extension = OperatingSystem.IsWindows() ? ".exe" : string.Empty;
+        return pathEnv.Split(Path.PathSeparator)
+            .Select(dir => Path.Combine(dir, $"dotnet-gitversion{extension}"))
+            .Any(File.Exists);
+    }
+
+    private static async Task<Result> Install()
+    {
+        try
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    ArgumentList = { "tool", "install", "--global", "GitVersion.Tool" },
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                }
+            };
+
+            process.Start();
+            var output = await process.StandardOutput.ReadToEndAsync();
+            var error = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            return process.ExitCode == 0
+                ? Result.Success()
+                : Result.Failure(error);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure(ex.Message);
+        }
+    }
+
+    private static async Task<Result<string>> Execute()
+    {
         try
         {
             var process = new Process


### PR DESCRIPTION
## Summary
- ensure DeployerTool installs GitVersion on demand
- revert Azure Pipeline to not handle GitVersion

## Testing
- `dotnet test --no-build` *(fails: project files not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fcd5f5238832faeeeb2fa381e3253