### PR TITLE
Fix Android APK naming

### DIFF
--- a/src/DotnetPackaging.Deployment/Platforms/Android/AndroidDeployment.cs
+++ b/src/DotnetPackaging.Deployment/Platforms/Android/AndroidDeployment.cs
@@ -48,8 +48,15 @@ public class AndroidDeployment(IDotnet dotnet, Path projectPath, AndroidDeployme
     private IEnumerable<INamedByteSource> ApkFiles(IContainer directory)
     {
         return directory.ResourcesWithPathsRecursive()
-            .Where(file => file.Name.EndsWith(".apk"))
-            .Select(resource => new Resource(options.PackageName + "-" + options.ApplicationDisplayVersion + "-android" + ".apk", resource));
+            .Where(file => file.Name.EndsWith(".apk", StringComparison.OrdinalIgnoreCase))
+            .Select(resource =>
+            {
+                var originalName = global::System.IO.Path.GetFileNameWithoutExtension(resource.Name);
+                var dashIndex = originalName.LastIndexOf('-');
+                var suffix = dashIndex >= 0 ? originalName[dashIndex..] : string.Empty;
+                var finalName = $"{options.PackageName}-{options.ApplicationDisplayVersion}-android{suffix}.apk";
+                return (INamedByteSource)new Resource(finalName, resource);
+            });
     }
 
     private static string CreateArgs(DeploymentOptions deploymentOptions, string keyStorePath, string androidSdkPath)

--- a/src/DotnetPackaging.Deployment/Platforms/Android/AndroidDeployment.cs
+++ b/src/DotnetPackaging.Deployment/Platforms/Android/AndroidDeployment.cs
@@ -56,7 +56,9 @@ public class AndroidDeployment(IDotnet dotnet, Path projectPath, AndroidDeployme
                 var suffix = dashIndex >= 0 ? originalName[dashIndex..] : string.Empty;
                 var finalName = $"{options.PackageName}-{options.ApplicationDisplayVersion}-android{suffix}.apk";
                 return (INamedByteSource)new Resource(finalName, resource);
-            });
+            })
+            .GroupBy(res => res.Name)
+            .Select(group => group.First());
     }
 
     private static string CreateArgs(DeploymentOptions deploymentOptions, string keyStorePath, string androidSdkPath)

--- a/test/DotnetPackaging.Deployment.Tests/ApkNamingTests.cs
+++ b/test/DotnetPackaging.Deployment.Tests/ApkNamingTests.cs
@@ -37,6 +37,40 @@ public class ApkNamingTests
             "AngorApp-1.0.0-android-Signed.apk");
     }
 
+    [Fact]
+    public async Task Ignores_duplicate_final_apk_names()
+    {
+        var files = new Dictionary<string, IByteSource>
+        {
+            ["io.Angor.AngorApp.apk"] = ByteSource.FromString("a"),
+            ["io.Angor.AngorApp-Signed.apk"] = ByteSource.FromString("b"),
+            ["sub/io.Angor.AngorApp.apk"] = ByteSource.FromString("c"),
+            ["sub/io.Angor.AngorApp-Signed.apk"] = ByteSource.FromString("d")
+        };
+
+        var container = files.ToRootContainer().Map(rc => rc.AsContainer()).Value;
+        var dotnet = new FakeDotnet(Result.Success((IContainer)container));
+
+        var options = new AndroidDeployment.DeploymentOptions
+        {
+            PackageName = "AngorApp",
+            ApplicationVersion = 1,
+            ApplicationDisplayVersion = "1.0.0",
+            AndroidSigningKeyStore = ByteSource.FromString("dummy"),
+            SigningKeyAlias = "alias",
+            SigningStorePass = "store",
+            SigningKeyPass = "key"
+        };
+
+        var deployment = new AndroidDeployment(dotnet, new Path("project.csproj"), options, Maybe<ILogger>.None);
+        var result = await deployment.Create();
+
+        result.Should().Succeed();
+        result.Value.Select(x => x.Name).Should().BeEquivalentTo(
+            "AngorApp-1.0.0-android.apk",
+            "AngorApp-1.0.0-android-Signed.apk");
+    }
+
     private class FakeDotnet(Result<IContainer> publishResult) : IDotnet
     {
         public Task<Result<IContainer>> Publish(string projectPath, string arguments = "") => Task.FromResult(publishResult);

--- a/test/DotnetPackaging.Deployment.Tests/ApkNamingTests.cs
+++ b/test/DotnetPackaging.Deployment.Tests/ApkNamingTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using DotnetPackaging.Deployment.Platforms.Android;
+
+namespace DotnetPackaging.Deployment.Tests;
+
+public class ApkNamingTests
+{
+    [Fact]
+    public async Task Keeps_suffix_from_original_file_name()
+    {
+        var files = new Dictionary<string, IByteSource>
+        {
+            ["io.Angor.AngorApp.apk"] = ByteSource.FromString("a"),
+            ["io.Angor.AngorApp-Signed.apk"] = ByteSource.FromString("b")
+        };
+
+        var container = files.ToRootContainer().Map(rc => rc.AsContainer()).Value;
+        var dotnet = new FakeDotnet(Result.Success((IContainer)container));
+
+        var options = new AndroidDeployment.DeploymentOptions
+        {
+            PackageName = "AngorApp",
+            ApplicationVersion = 1,
+            ApplicationDisplayVersion = "1.0.0",
+            AndroidSigningKeyStore = ByteSource.FromString("dummy"),
+            SigningKeyAlias = "alias",
+            SigningStorePass = "store",
+            SigningKeyPass = "key"
+        };
+
+        var deployment = new AndroidDeployment(dotnet, new Path("project.csproj"), options, Maybe<ILogger>.None);
+        var result = await deployment.Create();
+
+        result.Should().Succeed();
+        result.Value.Select(x => x.Name).Should().BeEquivalentTo(
+            "AngorApp-1.0.0-android.apk",
+            "AngorApp-1.0.0-android-Signed.apk");
+    }
+
+    private class FakeDotnet(Result<IContainer> publishResult) : IDotnet
+    {
+        public Task<Result<IContainer>> Publish(string projectPath, string arguments = "") => Task.FromResult(publishResult);
+        public Task<Result> Push(string packagePath, string apiKey) => Task.FromResult(Result.Success());
+        public Task<Result<INamedByteSource>> Pack(string projectPath, string version) => Task.FromResult(Result.Failure<INamedByteSource>("Not implemented"));
+    }
+}


### PR DESCRIPTION
## Summary
- keep the original APK suffix when packaging Android apps
- add regression test for APK name suffix handling

## Testing
- `dotnet test --no-build` *(fails: Process failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_688776550cf0832fbf73c9c27610dac6