### PR TITLE
Add platform-based logging context

### DIFF
--- a/src/DotnetPackaging.Console/Program.cs
+++ b/src/DotnetPackaging.Console/Program.cs
@@ -16,7 +16,7 @@ static class Program
     public static Task<int> Main(string[] args)
     {
         Log.Logger = new LoggerConfiguration()
-            .WriteTo.Console()
+            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3} {Platform}] {Message:lj}{NewLine}{Exception}")
             .CreateLogger();
         
         var rootCommand = new RootCommand();

--- a/src/DotnetPackaging.DeployerTool/Program.cs
+++ b/src/DotnetPackaging.DeployerTool/Program.cs
@@ -16,7 +16,9 @@ static class Program
 {
     public static async Task<int> Main(string[] args)
     {
-        Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3} {Platform}] {Message:lj}{NewLine}{Exception}")
+            .CreateLogger();
 
         var root = new RootCommand("Deployment tool for DotnetPackaging");
         root.AddCommand(CreateNugetCommand());

--- a/src/DotnetPackaging.Deployment/Core/LoggerExtensions.cs
+++ b/src/DotnetPackaging.Deployment/Core/LoggerExtensions.cs
@@ -1,0 +1,12 @@
+using Serilog;
+
+namespace DotnetPackaging.Deployment.Core;
+
+public static class LoggerExtensions
+{
+    public static Maybe<ILogger> ForPlatform(this Maybe<ILogger> logger, string platform)
+    {
+        return logger.Map(l => l.ForContext("Platform", platform));
+    }
+}
+

--- a/src/DotnetPackaging.Deployment/Core/Packager.cs
+++ b/src/DotnetPackaging.Deployment/Core/Packager.cs
@@ -9,17 +9,20 @@ public class Packager(IDotnet dotnet, Maybe<ILogger> logger)
 {
     public Task<Result<IEnumerable<INamedByteSource>>> CreateWindowsPackages(Path path, WindowsDeployment.DeploymentOptions deploymentOptions)
     {
-        return new WindowsDeployment(dotnet, path, deploymentOptions, logger).Create();
+        var platformLogger = logger.ForPlatform("Windows");
+        return new WindowsDeployment(dotnet, path, deploymentOptions, platformLogger).Create();
     }
 
     public Task<Result<IEnumerable<INamedByteSource>>> CreateAndroidPackages(Path path, AndroidDeployment.DeploymentOptions options)
     {
-        return new AndroidDeployment(dotnet, path, options, logger).Create();
+        var platformLogger = logger.ForPlatform("Android");
+        return new AndroidDeployment(dotnet, path, options, platformLogger).Create();
     }
     
     public Task<Result<IEnumerable<INamedByteSource>>> CreateLinuxPackages(Path path, AppImage.Metadata.AppImageMetadata metadata)
     {
-        return new LinuxDeployment(dotnet, path, metadata, logger).Create();
+        var platformLogger = logger.ForPlatform("Linux");
+        return new LinuxDeployment(dotnet, path, metadata, platformLogger).Create();
     }
     
     public Task<Result<INamedByteSource>> CreateNugetPackage(Path path, string version)
@@ -34,7 +37,9 @@ public class Packager(IDotnet dotnet, Maybe<ILogger> logger)
     
     public Task<Result<WasmApp>> CreateWasmSite(string projectPath)
     {
-        return dotnet.Publish(projectPath)
+        var platformLogger = logger.ForPlatform("Wasm");
+        var platformDotnet = new Dotnet(((Dotnet)dotnet).Command, platformLogger);
+        return platformDotnet.Publish(projectPath)
             .Bind(WasmApp.Create);
     }
 }


### PR DESCRIPTION
## Summary
- add logger extension for platform tagging
- use platform context in packager
- show platform in console logger output

## Testing
- `dotnet test` *(fails: missing .NET runtime and MSBuild errors)*

------
https://chatgpt.com/codex/tasks/task_e_68877bfd20b4832fafd6c12f184b870b