### PR TITLE
Fix GitVersion fallback for NuGet version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ from CI pipelines like Azure DevOps.
 
 The Azure Pipeline determines the version using [GitVersion](https://gitversion.net),
 so releases automatically follow the Git history. The tool locates the git repository by walking up from the solution directory
-so the correct repository is used. If GitVersion fails, the pipeline falls back to `git describe --tags --long`
+so the correct repository is used. It first tries `NuGetVersion` or `MajorMinorPatch`
+from GitVersion to ensure the value is NuGet compatible. If GitVersion fails, the pipeline falls back to `git describe --tags --long`
 and converts the result into a NuGet-compatible version.
 
 You can publish the tool itself using a single command:

--- a/src/DotnetPackaging/GitVersionRunner.cs
+++ b/src/DotnetPackaging/GitVersionRunner.cs
@@ -45,7 +45,7 @@ public static class GitVersionRunner
         return result.IsSuccess ? Result.Success() : Result.Failure(result.Error);
     }
 
-    private static readonly string[] PreferredFields = ["NuGetVersionV2", "NuGetVersion", "SemVer", "FullSemVer"];
+    private static readonly string[] PreferredFields = ["NuGetVersionV2", "NuGetVersion", "MajorMinorPatch", "SemVer", "FullSemVer"];
 
     private static async Task<Result<string>> Execute(Command command, string repoPath)
     {


### PR DESCRIPTION
## Summary
- prefer `MajorMinorPatch` when extracting version information
- document how GitVersion chooses a NuGet-friendly version

## Testing
- `dotnet test DotnetPackaging.sln -v minimal` *(fails: Could not install .NET 8 framework, Android SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_688787a063ec832f92a62999cc935e3f