### PR TITLE
Run DeployerTool in verification mode for branch builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,9 @@ steps:
       if [ -n "$(ProjectNamePattern)" ]; then
         args="--name-pattern $(ProjectNamePattern)"
       fi
+      if [[ "$(Build.SourceBranch)" != refs/tags/* ]]; then
+        args="--no-push $args"
+      fi
       dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- \
         nuget --solution DotnetPackaging.sln --api-key $(NuGetApiKey) $args
     displayName: Publish Packages


### PR DESCRIPTION
## Summary
- allow DeployerTool to skip pushing packages with `--no-push`
- support `--no-push` in pipeline when build is not tagged
- compile packages during branch builds for verification

## Testing
- `dotnet build DotnetPackaging.sln -c Release -nologo`
- `dotnet test DotnetPackaging.sln -c Release -nologo --no-build` *(fails: missing .NET 8 runtime and invalid project paths)*


------
https://chatgpt.com/codex/tasks/task_e_68878a10254c832f81445fd42e7ebb1b