### PR TITLE
Fix DeployerTool call on master builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,8 +22,7 @@ steps:
       if ("$(ProjectNamePattern)" -ne "") {
         $args = "--name-pattern $(ProjectNamePattern)"
       }
-      dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- \
-        nuget --solution DotnetPackaging.sln --api-key $env:NUGET_API_KEY $args
+      dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- nuget --solution DotnetPackaging.sln --api-key $env:NUGET_API_KEY $args
     displayName: Publish NuGet packages
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     env:
@@ -34,8 +33,7 @@ steps:
       if ("$(ProjectNamePattern)" -ne "") {
         $args = "$args --name-pattern $(ProjectNamePattern)"
       }
-      dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- \
-        nuget --solution DotnetPackaging.sln --api-key $env:NUGET_API_KEY $args
+      dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- nuget --solution DotnetPackaging.sln --api-key $env:NUGET_API_KEY $args
     displayName: Publish NuGet packages (dry run)
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
     env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,14 +17,26 @@ steps:
   - script: dotnet build src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -c Release
     displayName: Build DeployerTool
 
-  - bash: |
-      args=""
-      if [ -n "$(ProjectNamePattern)" ]; then
-        args="--name-pattern $(ProjectNamePattern)"
-      fi
-      if [[ "$(Build.SourceBranch)" != refs/tags/* ]]; then
-        args="--no-push $args"
-      fi
+  - pwsh: |
+      $args = ""
+      if ("$(ProjectNamePattern)" -ne "") {
+        $args = "--name-pattern $(ProjectNamePattern)"
+      }
       dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- \
-        nuget --solution DotnetPackaging.sln --api-key $(NuGetApiKey) $args
-    displayName: Publish Packages
+        nuget --solution DotnetPackaging.sln --api-key $env:NUGET_API_KEY $args
+    displayName: Publish NuGet packages
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    env:
+      NUGET_API_KEY: $(NuGetApiKey)
+
+  - pwsh: |
+      $args = "--no-push"
+      if ("$(ProjectNamePattern)" -ne "") {
+        $args = "$args --name-pattern $(ProjectNamePattern)"
+      }
+      dotnet run --project src/DotnetPackaging.DeployerTool/DotnetPackaging.DeployerTool.csproj -- \
+        nuget --solution DotnetPackaging.sln --api-key $env:NUGET_API_KEY $args
+    displayName: Publish NuGet packages (dry run)
+    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+    env:
+      NUGET_API_KEY: $(NuGetApiKey)


### PR DESCRIPTION
## Summary
- adjust pipeline logic to skip `--no-push` when building `master`
- switch from bash script to two PowerShell tasks for invoking DeployerTool

## Testing
- `dotnet test DotnetPackaging.sln --no-build --verbosity minimal`
- `dotnet test test/DotnetPackaging.Deb.Tests/DotnetPackaging.Deb.Tests.csproj --verbosity minimal` *(fails: central package version management error)*

------
https://chatgpt.com/codex/tasks/task_e_6887ee79eb0c832fa652ae02a80f6c23