### PR TITLE
chore: formatting + toggle Zafiro references (Debug local, Release NuGet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ FodyWeavers.xsd
 
 /.idea/.idea.DotnetPackaging/.idea
 dotnet-install.sh
+
+# Test/runtime artifacts
+squashfs-root/

--- a/src/DotnetPackaging.AppImage/AppImageFactory.cs
+++ b/src/DotnetPackaging.AppImage/AppImageFactory.cs
@@ -10,9 +10,10 @@ public class AppImageFactory
 {
     public Task<Result<AppImageContainer>> Create(
         IContainer applicationRoot,
-        AppImageMetadata appImageMetadata)
+        AppImageMetadata appImageMetadata,
+        AppImageOptions? options = null)
     {
-        var executableFile = 
+        var executableFile =
             from exec in GetExecutable(applicationRoot)
             from arch in exec.GetArchitecture()
             select new Executable
@@ -21,10 +22,152 @@ public class AppImageFactory
                 Architecture = arch,
             };
 
-        return executableFile.Bind(execFile => Create(applicationRoot, appImageMetadata, execFile));
+        return executableFile.Bind(execFile => Create(applicationRoot, appImageMetadata, execFile, options ?? new AppImageOptions()));
     }
 
-    private static Task<Result<AppImageContainer>> Create(IContainer applicationRoot, AppImageMetadata appImageMetadata, Executable executableFile)
+    // Build an AppDir (as a RootContainer) from a raw application directory
+    public Task<Result<RootContainer>> BuildAppDir(
+        IContainer applicationRoot,
+        AppImageMetadata appImageMetadata,
+        AppImageOptions? options = null)
+    {
+        var effectiveOptions = options ?? new AppImageOptions();
+        var appDirResult = from exec in GetExecutable(applicationRoot)
+                           from root in BuildAppDirInternal(applicationRoot, appImageMetadata, exec, effectiveOptions)
+                           select root;
+        return appDirResult;
+    }
+
+    private static Task<Result<RootContainer>> BuildAppDirInternal(
+        IContainer applicationRoot,
+        AppImageMetadata appImageMetadata,
+        INamedByteSource executable,
+        AppImageOptions options)
+    {
+        var executableName = executable.Name;
+
+        var desktopFile = appImageMetadata.ToDesktopFile($"/usr/bin/{executableName}");
+
+        var appRunContent = ByteSource.FromString($"#!/bin/bash\nexec \"$APPDIR/usr/bin/{executableName}\" \"$@\"");
+        var desktopContent = ByteSource.FromString(MetadataGenerator.DesktopFileContents(desktopFile));
+        var appdataContent = ByteSource.FromString(MetadataGenerator.AppStreamXml(appImageMetadata.ToAppStream()));
+
+        // Get all application files with their relative paths
+        var namedByteSourceWithPaths = applicationRoot.ResourcesWithPathsRecursive();
+
+        var applicationFiles = namedByteSourceWithPaths
+            .ToDictionary(
+                file => $"usr/bin/{file.FullPath()}", IByteSource (file) => file);
+
+        var files = new Dictionary<string, IByteSource>
+        {
+            ["AppRun"] = appRunContent,
+            [appImageMetadata.DesktopFileName] = desktopContent,
+            [$"usr/share/metainfo/{appImageMetadata.AppDataFileName}"] = appdataContent,
+        };
+
+        // Add all application files to the files dictionary
+        foreach (var appFile in applicationFiles)
+        {
+            files[appFile.Key] = appFile.Value;
+        }
+
+        // Icon discovery and installation
+        var iconName = options.IconNameOverride.GetValueOrDefault(appImageMetadata.IconName);
+        var iconFiles = Icons.IconInstaller.Discover(applicationRoot, appImageMetadata, iconName, options.EnableDirIcon);
+        foreach (var icon in iconFiles)
+        {
+            files[icon.Key] = icon.Value;
+        }
+
+        // Fallback: if no icons discovered, try root-only quick check (icon.svg, icon-256.png, icon.png)
+        if (!iconFiles.Any())
+        {
+            var all = namedByteSourceWithPaths.ToList();
+            bool IsRoot(INamedByteSource f)
+            {
+                var fp = ((INamedWithPath)f).FullPath().ToString();
+                return !fp.Contains('/') && !fp.Contains('\\');
+            }
+            var roots = all.Where(IsRoot).ToList();
+            INamedByteSource? svg = roots.FirstOrDefault(f => f.Name.Equals("icon.svg", StringComparison.OrdinalIgnoreCase) || f.Name.EndsWith("-icon.svg", StringComparison.OrdinalIgnoreCase));
+            INamedByteSource? png256 = roots.FirstOrDefault(f => f.Name.Equals("icon-256.png", StringComparison.OrdinalIgnoreCase));
+            INamedByteSource? pngAny = png256 ?? roots.FirstOrDefault(f => f.Name.Equals("icon.png", StringComparison.OrdinalIgnoreCase));
+
+            if (svg != null)
+            {
+                files[$"usr/share/icons/hicolor/scalable/apps/{appImageMetadata.IconName}.svg"] = svg;
+            }
+            if (pngAny != null)
+            {
+                files[$"usr/share/icons/hicolor/256x256/apps/{appImageMetadata.IconName}.png"] = pngAny;
+                if (options.EnableDirIcon)
+                {
+                    files[".DirIcon"] = pngAny;
+                }
+            }
+        }
+
+        return Task.FromResult(files.ToRootContainer());
+    }
+
+    // New: create directly from an AppDir-shaped container (no file synthesis, no icon heuristics)
+    public Task<Result<AppImageContainer>> CreateFromAppDir(
+        IContainer appDir,
+        AppImageMetadata appImageMetadata,
+        string? executableRelativePath = null,
+        Architecture? architectureOverride = null)
+    {
+        var execResult = from exec in GetExecutableFromAppDir(appDir, executableRelativePath)
+                         from arch in architectureOverride != null
+                             ? Task.FromResult(Result.Success(architectureOverride))
+                             : exec.GetArchitecture()
+                         select new Executable
+                         {
+                             Resource = exec,
+                             Architecture = arch,
+                         };
+
+        return execResult.Bind(executable =>
+        {
+            // Use the appDir container as-is; assume it already contains AppRun, .desktop, icons, etc.
+            var appImage = from rt in RuntimeFactory.Create(executable.Architecture)
+                           from unixDir in Result.Try(() => new Container("", appDir.Resources, appDir.Subcontainers).ToUnixDirectory(new MetadataResolver(executable)))
+                           select new AppImageContainer(rt, unixDir);
+            return appImage;
+        });
+    }
+
+    private static async Task<Result<INamedByteSourceWithPath>> GetExecutableFromAppDir(IContainer appDir, string? executableRelativePath)
+    {
+        if (!string.IsNullOrWhiteSpace(executableRelativePath))
+        {
+            var normalizedTarget = executableRelativePath.Replace('\\', '/');
+            var found = appDir.ResourcesWithPathsRecursive()
+                .FirstOrDefault(s => ((INamedWithPath)s).FullPath().ToString().Replace('\\', '/')
+                    .Equals(normalizedTarget, StringComparison.OrdinalIgnoreCase));
+            return found is not null
+                ? Result.Success(found)
+                : Result.Failure<INamedByteSourceWithPath>($"Executable '{executableRelativePath}' not found in AppDir");
+        }
+
+        // Default: pick first ELF under usr/bin, else first ELF anywhere
+        var all = appDir.ResourcesWithPathsRecursive().ToList();
+        var underUsrBin = all.Where(s => ((INamedWithPath)s).FullPath().ToString().Replace('\\', '/').StartsWith("usr/bin/", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var s in underUsrBin.Concat(all))
+        {
+            var elfCheck = await s.IsElf();
+            if (elfCheck.IsSuccess && elfCheck.Value)
+            {
+                return Result.Success(s);
+            }
+        }
+
+        return Result.Failure<INamedByteSourceWithPath>("No ELF executable found in the AppDir (looked under usr/bin and then anywhere)");
+    }
+
+    private static Task<Result<AppImageContainer>> Create(IContainer applicationRoot, AppImageMetadata appImageMetadata, Executable executableFile, AppImageOptions options)
     {
         var executableName = executableFile.Resource.Name;
 
@@ -54,12 +197,48 @@ public class AppImageFactory
             files[appFile.Key] = appFile.Value;
         }
 
+        // Icon discovery and installation
+        var iconName = options.IconNameOverride.GetValueOrDefault(appImageMetadata.IconName);
+        var iconFiles = Icons.IconInstaller.Discover(applicationRoot, appImageMetadata, iconName, options.EnableDirIcon);
+        foreach (var icon in iconFiles)
+        {
+            files[icon.Key] = icon.Value;
+        }
+
+        // Fallback: if no icons discovered, try root-only quick check (icon.svg, icon-256.png, icon.png)
+        if (!iconFiles.Any())
+        {
+            var all = namedByteSourceWithPaths.ToList();
+            bool IsRoot(INamedByteSource f)
+            {
+                var fp = ((INamedWithPath)f).FullPath().ToString();
+                return !fp.Contains('/') && !fp.Contains('\\');
+            }
+            var roots = all.Where(IsRoot).ToList();
+            INamedByteSource? svg = roots.FirstOrDefault(f => f.Name.Equals("icon.svg", StringComparison.OrdinalIgnoreCase) || f.Name.EndsWith("-icon.svg", StringComparison.OrdinalIgnoreCase));
+            INamedByteSource? png256 = roots.FirstOrDefault(f => f.Name.Equals("icon-256.png", StringComparison.OrdinalIgnoreCase));
+            INamedByteSource? pngAny = png256 ?? roots.FirstOrDefault(f => f.Name.Equals("icon.png", StringComparison.OrdinalIgnoreCase));
+
+            if (svg != null)
+            {
+                files[$"usr/share/icons/hicolor/scalable/apps/{iconName}.svg"] = svg;
+            }
+            if (pngAny != null)
+            {
+                files[$"usr/share/icons/hicolor/256x256/apps/{iconName}.png"] = pngAny;
+                if (options.EnableDirIcon)
+                {
+                    files[".DirIcon"] = pngAny;
+                }
+            }
+        }
+
         var rootContainer = files.ToRootContainer();
 
         var appImage = from rt in RuntimeFactory.Create(executableFile.Architecture)
-            from rootCont in rootContainer
-            from unixDir in Result.Try(() => rootCont.AsContainer().ToUnixDirectory(new MetadataResolver(executableFile)))
-            select new AppImageContainer(rt, unixDir);
+                       from rootCont in rootContainer
+                       from unixDir in Result.Try(() => rootCont.AsContainer().ToUnixDirectory(new MetadataResolver(executableFile)))
+                       select new AppImageContainer(rt, unixDir);
 
         return appImage;
     }

--- a/src/DotnetPackaging.AppImage/Core/AppImageExtensions.cs
+++ b/src/DotnetPackaging.AppImage/Core/AppImageExtensions.cs
@@ -6,7 +6,7 @@ namespace DotnetPackaging.AppImage.Core;
 public static class AppImageExtensions
 {
     private static int ordinal;
-    
+
     public static Task<Result<IByteSource>> ToByteSource(this AppImageContainer appImageContainer)
     {
         return SquashFS.Create(appImageContainer.Container).Map(async sqfs =>

--- a/src/DotnetPackaging.AppImage/Metadata/AppImageMetadata.cs
+++ b/src/DotnetPackaging.AppImage/Metadata/AppImageMetadata.cs
@@ -5,7 +5,7 @@ public class AppImageMetadata
     public string AppId { get; init; }           // "com.mycompany.fileexplorer"
     public string AppName { get; init; }         // "My File Explorer"
     public string PackageName { get; init; }    // "fileexplorer"
-    
+
     // Metadata fields
     public Maybe<string> Summary { get; init; } = Maybe<string>.None;
     public Maybe<string> Comment { get; init; } = Maybe<string>.None;
@@ -27,7 +27,7 @@ public class AppImageMetadata
     }
 
     // Convenience constructor
-    public AppImageMetadata(string appName, string? packageName = null) 
+    public AppImageMetadata(string appName, string? packageName = null)
         : this(
             appId: (packageName ?? appName).ToLowerInvariant().Replace(" ", "").Replace("-", ""),
             appName: appName,
@@ -67,7 +67,7 @@ public class AppImageMetadata
             DesktopId = Maybe<string>.From($"{PackageName}.desktop")
         };
     }
-    
+
     public string DesktopFileName => $"{PackageName}.desktop";
     public string AppDataFileName => $"{PackageName}.appdata.xml";
     public string AppImageFileName => $"{PackageName}.AppImage";

--- a/src/DotnetPackaging.AppImage/Metadata/MetadataResolver.cs
+++ b/src/DotnetPackaging.AppImage/Metadata/MetadataResolver.cs
@@ -22,7 +22,7 @@ internal class MetadataResolver : IMetadataResolver
             Permission.GroupRead | Permission.GroupExec |
             Permission.OtherRead | Permission.OtherExec
         );
-        
+
         return new Zafiro.DivineBytes.Unix.Metadata(directoryPermissions, 1000);
     }
 
@@ -32,9 +32,9 @@ internal class MetadataResolver : IMetadataResolver
         var isExecutable = executableFile.Resource.Name.Equals(file.Name, StringComparison.OrdinalIgnoreCase);
         // Check if this is the AppRun file, which is also executable
         var isAppRun = file.Name.Equals("AppRun", StringComparison.OrdinalIgnoreCase);
-        
+
         UnixPermissions filePermissions;
-        
+
         if (isExecutable || isAppRun)
         {
             // Executable file permissions: 755 (rwxr-xr-x)
@@ -57,7 +57,7 @@ internal class MetadataResolver : IMetadataResolver
                 Permission.OtherRead
             );
         }
-        
+
         return new Zafiro.DivineBytes.Unix.Metadata(filePermissions, 1000);
     }
 }

--- a/src/DotnetPackaging.Console/DotnetPackaging.Console.csproj
+++ b/src/DotnetPackaging.Console/DotnetPackaging.Console.csproj
@@ -11,12 +11,20 @@
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Zafiro.FileSystem.Local" />
-    <PackageReference Include="Zafiro.FileSystem.Unix" />
   </ItemGroup>
+  <!-- Always reference local projects within this repo -->
   <ItemGroup>
     <ProjectReference Include="..\DotnetPackaging.AppImage\DotnetPackaging.AppImage.csproj" />
     <ProjectReference Include="..\DotnetPackaging.Deb\DotnetPackaging.Deb.csproj" />
     <ProjectReference Include="..\DotnetPackaging\DotnetPackaging.csproj" />
+  </ItemGroup>
+  <!-- Toggle Zafiro: local projects in Debug, NuGet packages in Release (central versions in Directory.Packages.props) -->
+  <ItemGroup Condition="'$(UseLocalZafiroReferences)' == 'true'">
+    <ProjectReference Include="..\..\libs\Zafiro\src\Zafiro.FileSystem.Local\Zafiro.FileSystem.Local.csproj" />
+    <ProjectReference Include="..\..\libs\Zafiro\src\Zafiro.FileSystem.Unix\Zafiro.FileSystem.Unix.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseLocalZafiroReferences)' == 'false'">
+    <PackageReference Include="Zafiro.FileSystem.Local" />
+    <PackageReference Include="Zafiro.FileSystem.Unix" />
   </ItemGroup>
 </Project>

--- a/src/DotnetPackaging.Deb/Archives/Ar/EntryMixin.cs
+++ b/src/DotnetPackaging.Deb/Archives/Ar/EntryMixin.cs
@@ -4,13 +4,13 @@ using Zafiro.FileSystem.Unix;
 
 namespace DotnetPackaging.Deb.Archives.Ar;
 
-public static class EntryMixin 
+public static class EntryMixin
 {
     public static IData ToData(this Entry entry)
     {
         return new CompositeData
         (
-            entry.FileIdentifier(), 
+            entry.FileIdentifier(),
             entry.FileModificationTimestamp(),
             entry.OwnerId(),
             entry.GroupId(),

--- a/src/DotnetPackaging.Deb/Archives/Deb/DebMixin.cs
+++ b/src/DotnetPackaging.Deb/Archives/Deb/DebMixin.cs
@@ -55,12 +55,12 @@ public static class DebMixin
             LastModification = debFile.Metadata.ModificationTime,
             OwnerId = 0,
         };
-        
+
         var controlTarFile = ControlTarFile(debFile);
         return new Entry(new File("control.tar", controlTarFile.ToData()), properties);
     }
-    
-     private static TarFile ControlTarFile(DebFile deb)
+
+    private static TarFile ControlTarFile(DebFile deb)
     {
         var fileProperties = new TarFileProperties()
         {
@@ -71,7 +71,7 @@ public static class DebMixin
             OwnerUsername = "root",
             LastModification = deb.Metadata.ModificationTime,
         };
-        
+
         var dirProperties = new TarDirectoryProperties()
         {
             FileMode = "755".ToFileMode(),
@@ -96,13 +96,13 @@ public static class DebMixin
         var content = items.Compose() + "\n";
 
         var file = new File("control", Data.FromString(content));
-        
+
         var entries = new TarEntry[]
         {
             new DirectoryTarEntry("./", dirProperties),
             new FileTarEntry("./control", file, fileProperties)
         };
-        
+
         // TODO: Add other properties, too
         //Homepage: {deb.ControlMetadata.Homepage}
         //Vcs-Git: {deb.ControlMetadata.VcsGit}
@@ -110,7 +110,7 @@ public static class DebMixin
         //License: {deb.ControlMetadata.License}
         //Installed-Size: {deb.ControlMetadata.InstalledSize}
         //Recommends: {deb.ControlMetadata.Recommends}
-        
+
         var controlTarFile = new TarFile(entries.ToArray());
         return controlTarFile;
     }

--- a/src/DotnetPackaging.Deb/Archives/Tar/TarEntryMixin.cs
+++ b/src/DotnetPackaging.Deb/Archives/Tar/TarEntryMixin.cs
@@ -36,7 +36,7 @@ public static class TarEntryMixin
     /// </summary>
     public static IData Owner(this TarEntry entry) => Data.FromString(entry.Properties.OwnerId.GetValueOrDefault(1).ToOctal().NullTerminatedPaddedField(8), Encoding.ASCII);
 
-        /// <summary>
+    /// <summary>
     ///     From 116 to 124
     /// </summary>
     public static IData Group(this TarEntry entry) => Data.FromString(entry.Properties.GroupId.GetValueOrDefault(1).ToOctal().NullTerminatedPaddedField(8), Encoding.ASCII);

--- a/src/DotnetPackaging.Deb/Builder/TarEntryBuilder.cs
+++ b/src/DotnetPackaging.Deb/Builder/TarEntryBuilder.cs
@@ -22,7 +22,7 @@ public static class TarEntryBuilder
         var tarEntries = directoryEntries.Concat(allFiles);
         return tarEntries;
     }
-    
+
     private static IEnumerable<FileTarEntry> ImplicitFileEntries(PackageMetadata metadata, string executablePath)
     {
         return new FileTarEntry[]
@@ -31,7 +31,7 @@ public static class TarEntryBuilder
             new($"./usr/local/bin/{metadata.Package.ToLower()}", Data.FromString(TextTemplates.RunScript(executablePath), Encoding.ASCII), Misc.ExecutableFileProperties())
         }.Concat(GetIconEntry(metadata));
     }
-    
+
     private static IEnumerable<FileTarEntry> GetIconEntry(PackageMetadata metadata)
     {
         if (metadata.Icon.HasNoValue)
@@ -42,7 +42,7 @@ public static class TarEntryBuilder
         var size = metadata.Icon.Value.Size;
         return [new FileTarEntry($"./usr/share/icons/hicolor/{size}x{size}/apps/{metadata.Package.ToLower()}.png", metadata.Icon.Value, Misc.RegularFileProperties())];
     }
-    
+
     private static IEnumerable<TarEntry> TarEntriesFromFiles(IEnumerable<IRootedFile> files, PackageMetadata metadata, IFile executable)
     {
         return files.Select(x => new FileTarEntry($"./opt/{metadata.Package}/" + x.FullPath(), x.Value, GetFileProperties(x, executable.Name)));

--- a/src/DotnetPackaging.Msix.Tests/CompressionTests.cs
+++ b/src/DotnetPackaging.Msix.Tests/CompressionTests.cs
@@ -8,7 +8,7 @@ namespace MsixPackaging.Tests;
 public class CompressionTests
 {
     [Fact]
-    public async Task Store_compression_gives_different_bytes() 
+    public async Task Store_compression_gives_different_bytes()
     {
         var bytes = "hola que tal va la jodida cosa"u8.ToArray();
 

--- a/src/DotnetPackaging.Msix.Tests/MsixPackagerTests.cs
+++ b/src/DotnetPackaging.Msix.Tests/MsixPackagerTests.cs
@@ -18,13 +18,13 @@ public class MsixPackagerTests
     public MsixPackagerTests(ITestOutputHelper output)
     {
         Log.Logger = new LoggerConfiguration()
-            .WriteTo.TestOutput(output, outputTemplate: 
+            .WriteTo.TestOutput(output, outputTemplate:
                 "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext:l}: {Message:lj}{NewLine}{Exception}")
             .Enrich.FromLogContext()
             .MinimumLevel.Debug()
             .CreateLogger();
     }
-    
+
     [Fact]
     public async Task Minimal()
     {
@@ -54,7 +54,7 @@ public class MsixPackagerTests
     {
         await EnsureValid("FullAvaloniaApp");
     }
-    
+
     [Fact]
     public async Task MinimalWithMetadata()
     {
@@ -74,19 +74,19 @@ public class MsixPackagerTests
         var fs = new FileSystem();
         var directoryInfo = fs.DirectoryInfo.New($"TestFiles/{folderName}/Contents");
         var directoryContainer = new DirectoryContainer(directoryInfo);
-        
+
         var result = Msix.FromDirectory(directoryContainer, Log.Logger.AsMaybe());
-        
+
         // Verify the result is successful
         Assert.True(result.IsSuccess, $"Failed to create MSIX package: {result.Error}");
-        
+
         // Write the MSIX package to file
         await using var fileStream = File.Create($"TestFiles/{folderName}/Actual.msix");
         await result.Value.WriteTo(fileStream);
-        
+
         // Validate the created MSIX by attempting to unpack it
         var unpackResult = await MakeAppx.UnpackMsixAsync($"TestFiles/{folderName}/Actual.msix", "Unpack");
-        Assert.True(unpackResult.ExitCode == 0, 
+        Assert.True(unpackResult.ExitCode == 0,
             $"{unpackResult.ErrorMessage}: {unpackResult.ErrorOutput} - {unpackResult.StandardOutput}");
     }
 }

--- a/src/DotnetPackaging.Msix.Tests/Research/MsixResearchTests.cs
+++ b/src/DotnetPackaging.Msix.Tests/Research/MsixResearchTests.cs
@@ -25,20 +25,20 @@ public class MsixResearchTests
     {
         var compressedBytes = Tools.ExtractRawCompressedBytes(
             @"F:\Repos\SuperJMN\MsixCreator\MsixPackaging.Tests\bin\Debug\net9.0\TestFiles\ValidExe\Expected.msix", "HelloWorld.exe");
-    
+
         // 1. El bloque está completamente separado del LFH (Local File Header)
         // No necesitamos hacer Skip(44) ya que los bytes ya son solo del bloque
-    
+
         // 2. Los dos primeros bytes (00 09) son probablemente un marcador de bloque Deflate
         // En el formato Deflate, estos pueden indicar nivel de compresión o flags
-    
+
         // 3. Necesitamos normalizar estos bytes según las especificaciones de MSIX
         byte[] normalizedBytes = new byte[65560];
         Array.Copy(compressedBytes, 2, normalizedBytes, 0, 65560);
-    
+
         // Al normalizar los bytes, estamos tomando exactamente los 65560 bytes
         // excluyendo los dos primeros bytes (00 09) que son metadatos
-    
+
         string hash = Convert.ToBase64String(SHA256.HashData(normalizedBytes));
         Console.WriteLine($"Hash calculado: {hash}");
         Assert.Equal("j/tch6hTj5ey+gF7s81GyCj0/KLi3TQu8FwnCmJrRS4=", hash);
@@ -49,15 +49,15 @@ public class MsixResearchTests
     {
         var compressedBytes = Tools.ExtractRawCompressedBytes(
             @"F:\Repos\SuperJMN\MsixCreator\MsixPackaging.Tests\bin\Debug\net9.0\TestFiles\ValidExe\Expected.msix", "HelloWorld.exe");
-    
+
         // En el formato ZIP/APPX, hay posibilidad de que ciertos bits necesiten ser normalizados
         // Los primeros bytes de un bloque Deflate incluyen flags de compresión
         byte[] normalizedBytes = compressedBytes.ToArray();
-    
+
         // 1. Normalizar flags del encabezado Deflate
         normalizedBytes[0] = 0x78; // Valor estándar para Deflate (ZLIB)
         normalizedBytes[1] = 0x9C; // Nivel de compresión predeterminado
-    
+
         string hash = Convert.ToBase64String(SHA256.HashData(normalizedBytes.Take(65560).ToArray()));
         Console.WriteLine($"Hash calculado con flags normalizados: {hash}");
         Assert.Equal("j/tch6hTj5ey+gF7s81GyCj0/KLi3TQu8FwnCmJrRS4=", hash);
@@ -68,7 +68,7 @@ public class MsixResearchTests
     {
         var compressedBytes = Tools.ExtractRawCompressedBytes(
             @"F:\Repos\SuperJMN\MsixCreator\MsixPackaging.Tests\bin\Debug\net9.0\TestFiles\ValidExe\Expected.msix", "HelloWorld.exe");
-    
+
         byte[] testBytes = compressedBytes.ToArray();
         // Conservar bits importantes y limpiar los demás
         testBytes[0] &= 0xF0; // Conservar los 4 bits más significativos

--- a/src/DotnetPackaging.Msix.Tests/Research/Tools.cs
+++ b/src/DotnetPackaging.Msix.Tests/Research/Tools.cs
@@ -62,7 +62,7 @@ public class Tools
                         {
                             Console.WriteLine(
                                 $"Leyendo {headerCompressedSize} bytes comprimidos desde la posición {dataPosition}");
-                            return reader.ReadBytes((int) headerCompressedSize);
+                            return reader.ReadBytes((int)headerCompressedSize);
                         }
                         else
                         {
@@ -111,7 +111,7 @@ public class Tools
                                             // El tamaño comprimido es la distancia desde el fin del header hasta el inicio del descriptor
                                             if (actualCompressedSize == 0)
                                             {
-                                                actualCompressedSize = (uint) (descriptorPos - dataPosition);
+                                                actualCompressedSize = (uint)(descriptorPos - dataPosition);
                                                 Console.WriteLine(
                                                     $"Recalculando tamaño comprimido: {actualCompressedSize}");
                                             }
@@ -124,7 +124,7 @@ public class Tools
                                         {
                                             // Si encontramos el siguiente local header, el tamaño comprimido es la distancia
                                             // desde el inicio de los datos hasta este nuevo header
-                                            actualCompressedSize = (uint) (descriptorPos - dataPosition);
+                                            actualCompressedSize = (uint)(descriptorPos - dataPosition);
                                             Console.WriteLine(
                                                 $"Siguiente local header encontrado. Tamaño comprimido calculado: {actualCompressedSize}");
                                             foundDescriptor = true;
@@ -155,7 +155,7 @@ public class Tools
                             fs.Position = dataPosition;
                             Console.WriteLine(
                                 $"Leyendo {actualCompressedSize} bytes comprimidos desde la posición {dataPosition}");
-                            return reader.ReadBytes((int) actualCompressedSize);
+                            return reader.ReadBytes((int)actualCompressedSize);
                         }
                     }
 

--- a/src/DotnetPackaging.Msix/Core/Compression/Compressor.cs
+++ b/src/DotnetPackaging.Msix/Core/Compression/Compressor.cs
@@ -21,7 +21,7 @@ public static class Compressor
             }
         }
     }
-    
+
     public static IObservable<byte[]> Compressed(this IObservable<byte[]> source, CompressionLevel compressionLevel = CompressionLevel.Optimal)
     {
         return Observable.Create<byte[]>(observer =>
@@ -76,7 +76,7 @@ public static class Compressor
                 {
                     try
                     {
-                        deflateStream.Close(); 
+                        deflateStream.Close();
                         pipe.Writer.Complete();
                     }
                     catch (Exception ex)

--- a/src/DotnetPackaging.Msix/Core/Compression/Extensions.cs
+++ b/src/DotnetPackaging.Msix/Core/Compression/Extensions.cs
@@ -5,7 +5,7 @@ namespace DotnetPackaging.Msix.Core.Compression;
 public static class Extensions
 {
     public static IObservable<byte[]> ReadMyBytes(this Stream stream, long offset, int tamaño)
-    { 
+    {
         // Posicionamos el stream en el offset indicado.
         stream.Seek(offset, SeekOrigin.Begin);
 

--- a/src/DotnetPackaging.Msix/Core/Manifest/AppManifestGenerator.cs
+++ b/src/DotnetPackaging.Msix/Core/Manifest/AppManifestGenerator.cs
@@ -125,7 +125,7 @@ public class AppManifestGenerator
             OmitXmlDeclaration = false,
             Encoding = System.Text.Encoding.UTF8
         };
-            
+
         using (var xmlWriter = XmlWriter.Create(stream, settings))
         {
             doc.Save(xmlWriter);

--- a/src/DotnetPackaging.Msix/Core/MsixBuilder.cs
+++ b/src/DotnetPackaging.Msix/Core/MsixBuilder.cs
@@ -16,7 +16,7 @@ public class MsixBuilder : IAsyncDisposable
     private readonly List<MsixEntry> entries = new List<MsixEntry>();
     private readonly List<long> localHeaderOffsets = new List<long>();
     private bool finished = false;
-    
+
     // Constant indicating we always use Zip64
     private const bool AlwaysUseZip64 = true;
 
@@ -74,10 +74,10 @@ public class MsixBuilder : IAsyncDisposable
             // Name
             byte[] nameBytes = Encoding.UTF8.GetBytes(entry.FullPath);
             writer.Write((short)nameBytes.Length);
-            
+
             // Extra field for Zip64
             writer.Write((short)0); // No extra field, but still using Zip64 features elsewhere
-            
+
             // File name
             writer.Write(nameBytes);
         }

--- a/src/DotnetPackaging.Msix/Msix.cs
+++ b/src/DotnetPackaging.Msix/Msix.cs
@@ -14,7 +14,7 @@ public class Msix
     {
         return new MsixPackager(logger).Pack(container);
     }
-    
+
     public static Result<IByteSource> FromDirectoryAndMetadata(IContainer container, AppManifestMetadata metadata, Maybe<ILogger> logger)
     {
         var generateAppManifest = AppManifestGenerator.GenerateAppManifest(metadata);

--- a/src/DotnetPackaging/AppStreamXmlGenerator.cs
+++ b/src/DotnetPackaging/AppStreamXmlGenerator.cs
@@ -22,11 +22,11 @@ public static class AppStreamXmlGenerator
 
         return component;
     }
-    
+
     private static XElement GenerateScreenshots(PackageMetadata options)
     {
         var screenshotsElement = new XElement("screenshots");
-        
+
         options.ScreenshotUrls.Execute(urls =>
         {
             foreach (var url in urls)
@@ -34,7 +34,7 @@ public static class AppStreamXmlGenerator
                 screenshotsElement.Add(new XElement("screenshot", new XAttribute("type", "default"), new XElement("image", url)));
             }
         });
-       
+
         return screenshotsElement;
     }
 }

--- a/src/DotnetPackaging/Architecture.cs
+++ b/src/DotnetPackaging/Architecture.cs
@@ -8,7 +8,7 @@ public class Architecture
 
     public static Architecture X86 = new("X86", "i386", "i386");
     public static Architecture X64 = new("X64", "amd64", "x86_64");
-    public static Architecture Arm64 = new("ARM64", "arm64", "aarch64"); 
+    public static Architecture Arm64 = new("ARM64", "arm64", "aarch64");
     public static Architecture Arm32 = new("ARM32", "armhf", "armhf");
     public static Architecture All = new("All", "all", "all");
 

--- a/src/DotnetPackaging/BuildUtils.cs
+++ b/src/DotnetPackaging/BuildUtils.cs
@@ -16,7 +16,7 @@ public static class BuildUtils
         var package = setup.Package.Or(setup.Name).GetValueOrDefault(exec.Name.Replace(".Desktop", ""));
         var version = setup.Version.GetValueOrDefault("1.0.0");
         var name = setup.Name.GetValueOrDefault(directory.Name);
-        
+
         var packageMetadata = new PackageMetadata(name, architecture, isTerminal, package, version)
         {
             Architecture = architecture,

--- a/src/DotnetPackaging/FromDirectoryOptions.cs
+++ b/src/DotnetPackaging/FromDirectoryOptions.cs
@@ -7,7 +7,7 @@ public class FromDirectoryOptions
     public Maybe<string> ExecutableName { get; private set; }
     public Maybe<Architecture> Architecture { get; private set; } = Maybe<Architecture>.None;
     public Maybe<IIcon> Icon { get; private set; } = Maybe<IIcon>.None;
-    
+
     /// <summary>
     /// Application name (AppName)
     /// </summary>
@@ -27,7 +27,7 @@ public class FromDirectoryOptions
     public Maybe<string> Section { get; private set; } = Maybe<string>.None;
     public Maybe<string> Version { get; private set; } = Maybe<string>.None;
     public Maybe<string> VcsBrowser { get; private set; } = Maybe<string>.None;
-    public Maybe<string> VcsGit { get; private set; } = Maybe<string>.None; 
+    public Maybe<string> VcsGit { get; private set; } = Maybe<string>.None;
     public Maybe<long> InstalledSize { get; private set; } = Maybe<long>.None;
     public Maybe<DateTimeOffset> ModificationTime { get; private set; } = Maybe<DateTimeOffset>.None;
     public bool IsTerminal { get; private set; }
@@ -38,7 +38,7 @@ public class FromDirectoryOptions
         {
             throw new ArgumentException("Can't be null or empty", package);
         }
-        
+
         Package = package;
         return this;
     }
@@ -49,7 +49,7 @@ public class FromDirectoryOptions
         {
             throw new ArgumentException("Can't be null or empty", packageId);
         }
-        
+
         Id = packageId;
         return this;
     }
@@ -60,7 +60,7 @@ public class FromDirectoryOptions
         {
             throw new ArgumentException("Can't be null or empty", executableName);
         }
-        
+
         ExecutableName = executableName;
         return this;
     }
@@ -88,7 +88,7 @@ public class FromDirectoryOptions
         {
             throw new ArgumentException("Can't be null or empty", appName);
         }
-        
+
         Name = Maybe<string>.From(appName);
         return this;
     }
@@ -111,7 +111,7 @@ public class FromDirectoryOptions
             throw new ArgumentException("Can't be null or empty", startupWmClass);
         }
 
-        
+
         StartupWmClass = Maybe<string>.From(startupWmClass);
         return this;
     }
@@ -173,7 +173,7 @@ public class FromDirectoryOptions
         {
             throw new ArgumentException("Can't be null or empty", maintainer);
         }
-        
+
         Maintainer = Maybe<string>.From(maintainer);
         return this;
     }

--- a/src/DotnetPackaging/Icon.cs
+++ b/src/DotnetPackaging/Icon.cs
@@ -30,7 +30,7 @@ public class Icon : IIcon
     public long Length => data.Length;
 
     public int Size { get; }
-    
+
     public static Task<Result<IIcon>> FromData(IData data)
     {
         return FromImage(Image.Load(data.Bytes()));

--- a/src/DotnetPackaging/ImageMixin.cs
+++ b/src/DotnetPackaging/ImageMixin.cs
@@ -16,7 +16,7 @@ public static class ImageMixin
     {
         return image.Height == image.Width && MathMixin.IsPowerOf2(image.Width);
     }
-    
+
     public static Image Iconize(this Image originalImage)
     {
         // Determina la mayor dimensión de la imagen

--- a/src/DotnetPackaging/LinuxElfInspector.cs
+++ b/src/DotnetPackaging/LinuxElfInspector.cs
@@ -15,12 +15,12 @@ public static class LinuxElfInspector
     {
         return GetArchitecture(file.Bytes);
     }
-    
+
     public static async Task<Result<Architecture>> GetArchitecture(this IByteSource file)
     {
         return await GetArchitecture(file.Bytes);
     }
-    
+
     public static IObservable<Result<Architecture>> GetArchitecture(IObservable<byte[]> byteChunks)
     {
         var observable = byteChunks
@@ -75,7 +75,7 @@ public static class LinuxElfInspector
     {
         return IsElf(file.Bytes);
     }
-    
+
     public static IObservable<Result<bool>> IsElf(this IByteSource file)
     {
         return IsElf(file.Bytes);

--- a/src/DotnetPackaging/MathMixin.cs
+++ b/src/DotnetPackaging/MathMixin.cs
@@ -4,19 +4,19 @@ public static class MathMixin
 {
     public static int RoundUpToNearestMultiple(this int number, int multiple)
     {
-        return (number + multiple-1) / multiple * multiple;
+        return (number + multiple - 1) / multiple * multiple;
     }
 
     public static long RoundUpToNearestMultiple(this long number, long multiple)
     {
-        return (number + multiple-1) / multiple * multiple;
+        return (number + multiple - 1) / multiple * multiple;
     }
-    
-    public static bool IsPowerOf2(int n) 
+
+    public static bool IsPowerOf2(int n)
     {
         return n != 0 && (n & (n - 1)) == 0;
     }
-    
+
     public static int NextPowerOfTwo(int value)
     {
         value--;

--- a/src/DotnetPackaging/OptionsMixin.cs
+++ b/src/DotnetPackaging/OptionsMixin.cs
@@ -64,7 +64,7 @@ public static class OptionsMixin
         }
         if (options.IsTerminal.HasValue)
         {
-            setup.WithIsTerminal(options.IsTerminal.Value);   
+            setup.WithIsTerminal(options.IsTerminal.Value);
         }
         if (options.MainCategory.HasValue)
         {

--- a/src/DotnetPackaging/StringManipulationMixin.cs
+++ b/src/DotnetPackaging/StringManipulationMixin.cs
@@ -19,7 +19,7 @@ public static class StringManipulationMixin
     public static string NullTerminatedPaddedField(this string str, int size) => str.PaddedField(size).NullTerminated();
 
     public static string NullTerminated(this string str) => str + "\0";
-    
+
     public static string Compose(this Maybe<string>[] items)
     {
         var strings = items.Select(maybe => maybe.ToList()).Flatten();

--- a/test/DotnetPackaging.AppImage.Tests/CreateAppImage.cs
+++ b/test/DotnetPackaging.AppImage.Tests/CreateAppImage.cs
@@ -26,7 +26,7 @@ public class CreateAppImage
             ["Sample.md"] = ByteSource.FromString("**This is a sample file**"),
         }.ToRootContainer(); // Use root container without artificial name
 
-        var appImage = 
+        var appImage =
             from rt in Result.Success(new Runtime(ByteSource.FromString("THIS IS A RUNTIME"), Architecture.All))
             from rootContainer in containerResult
             from unixDir in Result.Try(() => rootContainer.AsContainer().ToUnixDirectory())
@@ -45,7 +45,7 @@ public class CreateAppImage
         var fileSystem = new FileSystem();
         var files = new DirectoryContainer(fileSystem.DirectoryInfo.New("TestFiles/Minimal"));
         var root = files.AsRoot();
-        
+
         var builder = new AppImageFactory();
         var appImage = builder.Create(root, new AppImageMetadata("com.superjmn.sampleapp", "Sample App", "sampleapp"));
 

--- a/test/DotnetPackaging.Deployment.Tests/Integration/PackagingTests.cs
+++ b/test/DotnetPackaging.Deployment.Tests/Integration/PackagingTests.cs
@@ -16,35 +16,35 @@ public class PackagingTests(ITestOutputHelper outputHelper)
     public static string DesktopProject = "/mnt/fast/Repos/SuperJMN-Zafiro/Zafiro.Avalonia/samples/TestApp/TestApp.Desktop/TestApp.Desktop.csproj";
     public static string AndroidProject = "/mnt/fast/Repos/SuperJMN-Zafiro/Zafiro.Avalonia/samples/TestApp/TestApp.Android/TestApp.Android.csproj";
     public static string WasmProject = "/mnt/fast/Repos/SuperJMN-Zafiro/Zafiro.Avalonia/samples/TestApp/TestApp.Browser/TestApp.Browser.csproj";
-    
+
     [Fact]
     public async Task Test_windows()
     {
         var dotnet = new Dotnet(new Command(Maybe<ILogger>.None), Maybe<ILogger>.None);
-        
+
         var options = new WindowsDeployment.DeploymentOptions
         {
             Version = "1.0.0",
             PackageName = "TestApp"
         };
-        
+
         var result = await new Packager(dotnet, Maybe<ILogger>.None)
             .CreateWindowsPackages(DesktopProject, options)
             .MapEach(source => source.WriteTo(OutputFolder + "/" + source.Name))
             .CombineSequentially();
-        
+
         result.Should().Succeed();
     }
-    
+
     [Fact]
     public async Task Test_android()
     {
         var logger = new LoggerConfiguration().WriteTo.TestOutput(outputHelper).CreateLogger();
-        
+
         var dotnet = new Dotnet(new Command(logger), logger);
-        
+
         var store = ByteSource.FromBytes(await File.ReadAllBytesAsync("Integration/test.keystore"));
-        
+
         var options = new AndroidDeployment.DeploymentOptions
         {
             PackageName = "TestApp",
@@ -55,7 +55,7 @@ public class PackagingTests(ITestOutputHelper outputHelper)
             SigningKeyPass = "test1234",
             SigningStorePass = "test1234",
         };
-        
+
         var result = await new Packager(dotnet, logger)
             .CreateAndroidPackages(AndroidProject, options)
             .MapEach(resource => resource.WriteTo(OutputFolder + "/" + resource.Name))
@@ -63,14 +63,14 @@ public class PackagingTests(ITestOutputHelper outputHelper)
 
         result.Should().Succeed();
     }
-    
-  public Packager CreatePackager()
+
+    public Packager CreatePackager()
     {
         var logger = new LoggerConfiguration().WriteTo.TestOutput(outputHelper).CreateLogger();
         var dotnet = new Dotnet(new Command(logger), logger);
         return new Packager(dotnet, logger);
     }
-    
+
     [Fact]
     public async Task Test_linux()
     {
@@ -81,20 +81,20 @@ public class PackagingTests(ITestOutputHelper outputHelper)
 
         result.Should().Succeed();
     }
-    
+
     [Fact]
     public async Task Test_nuget_pack()
     {
         var logger = new LoggerConfiguration().WriteTo.TestOutput(outputHelper).CreateLogger();
         var dotnet = new Dotnet(new Command(logger), logger);
-        
+
         var result = await CreatePackager()
             .CreateNugetPackage(DesktopProject, "1.0.0")
             .Bind(resource => resource.WriteTo(OutputFolder + "/" + resource.Name));
 
         result.Should().Succeed();
     }
-    
+
     [Fact]
     public async Task Test_nuget_push()
     {
@@ -108,7 +108,7 @@ public class PackagingTests(ITestOutputHelper outputHelper)
         var result = await deployer.PublishNugetPackages(["PATH_TO_PROJECT"], "VERSION", GitHubApiKey);
         result.Should().Succeed();
     }
-    
+
     [Fact]
     public async Task Create_GitHub_release()
     {
@@ -121,7 +121,7 @@ public class PackagingTests(ITestOutputHelper outputHelper)
 
         var releaseData = new ReleaseData("Test Release", "Tag", "BODY", isDraft: true);
         var gitHubRepositoryConfig = new GitHubRepositoryConfig("SuperJMN", "DotnetPackaging", GitHubApiKey);
-        
+
         // Using the new builder API that supports different projects per platform
         var androidOptions = new AndroidDeployment.DeploymentOptions()
         {
@@ -141,12 +141,12 @@ public class PackagingTests(ITestOutputHelper outputHelper)
             .ForLinux(DesktopProject)
             .ForAndroid(AndroidProject, androidOptions)
             .ForWebAssembly(WasmProject);
-        
+
         var result = await deployer.CreateGitHubRelease(releaseBuilder.Build(), gitHubRepositoryConfig, releaseData);
-        
+
         result.Should().Succeed();
     }
-    
+
     [Fact]
     public async Task Test_wasm_site()
     {
@@ -159,7 +159,7 @@ public class PackagingTests(ITestOutputHelper outputHelper)
 
         result.Should().Succeed();
     }
-    
+
     [Fact]
     public async Task Create_GitHub_release_from_solution_discovery()
     {
@@ -172,7 +172,7 @@ public class PackagingTests(ITestOutputHelper outputHelper)
 
         var releaseData = new ReleaseData("Test Release from Solution", "Tag", "BODY", isDraft: true);
         var gitHubRepositoryConfig = new GitHubRepositoryConfig("SuperJMN", "DotnetPackaging", GitHubApiKey);
-        
+
         var androidOptions = new AndroidDeployment.DeploymentOptions()
         {
             PackageName = "TestApp",
@@ -194,7 +194,7 @@ public class PackagingTests(ITestOutputHelper outputHelper)
             gitHubRepositoryConfig,
             releaseData,
             androidOptions);
-        
+
         result.Should().Succeed();
     }
 }


### PR DESCRIPTION
Summary of changes:
- Apply dotnet format across core modules to standardize code style (non-functional).
- Toggle Zafiro references by configuration: local ProjectReference in Debug, NuGet PackageReference in Release.
- AppImage: introduce new ways to create images (see details below).

Technical details:
- dotnet format executed on the solution; only tracked files were committed.
- src/Directory.Build.props drives UseLocalZafiroReferences=true by default and =false for Release.
- Updated src/DotnetPackaging.Console to conditionally reference libs/Zafiro (Debug) or Zafiro.* NuGet packages (Release).
- Centralized versions come from Directory.Packages.props (ZafiroVersion=33.0.5).
- Ignore AppImage test/runtime artifacts: added squashfs-root/ to .gitignore.

AppImage improvements:
- New creation flows:
  - BuildAppDir(applicationRoot, metadata, options?): builds an AppDir (RootContainer) from a raw application directory, synthesizing AppRun, .desktop and AppStream metadata, and installing icons (with icon name override and optional .DirIcon).
  - CreateFromAppDir(appDir, metadata, executableRelativePath?, architectureOverride?): creates an AppImage directly from a pre-built AppDir without re-synthesizing files; supports picking the executable path and overriding target architecture.
- Existing Create(...) now admits AppImageOptions for configurable icon discovery and .DirIcon generation.
- Improved icon discovery with fallback heuristics for root-level assets (icon.svg, icon-256.png, icon.png).

Testing steps:
- Build Debug: dotnet build DotnetPackaging.sln -c Debug
- Build Release: dotnet build DotnetPackaging.sln -c Release
- Run tests: dotnet test DotnetPackaging.sln
- Optional: dotnet format --verify-no-changes

Related issues/tickets:
- N/A