### PR TITLE
AppImage: stop writing debug artifacts to Desktop; gate optional outputs behind DOTNETPACKAGING_DEBUG

### DIFF
--- a/src/DotnetPackaging.AppImage/Core/AppImageExtensions.cs
+++ b/src/DotnetPackaging.AppImage/Core/AppImageExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Reactive.Linq;
 using Zafiro.DivineBytes;
 
@@ -14,8 +16,14 @@ public static class AppImageExtensions
             var appImageBytes = appImageContainer.Runtime.Concat(sqfs);
 
             var i = ordinal++;
-            await appImageContainer.Runtime.WriteTo($"/home/jmn/Escritorio/Runtime{i}-{appImageContainer.Runtime}.runtime").ConfigureAwait(false);
-            await sqfs.WriteTo($"/home/jmn/Escritorio/Image{i}-Container.sqfs").ConfigureAwait(false);
+            var debug = Environment.GetEnvironmentVariable("DOTNETPACKAGING_DEBUG");
+            if (!string.IsNullOrEmpty(debug) && (debug == "1" || debug.Equals("true", StringComparison.OrdinalIgnoreCase)))
+            {
+                var tempDir = System.IO.Path.GetTempPath();
+                await appImageContainer.Runtime.WriteTo(System.IO.Path.Combine(tempDir, $"Runtime{i}.runtime")).ConfigureAwait(false);
+                await sqfs.WriteTo(System.IO.Path.Combine(tempDir, $"Image{i}-Container.sqfs")).ConfigureAwait(false);
+            }
+
             var fromByteChunks = ByteSource.FromByteChunks(appImageBytes);
             var totalBytes = fromByteChunks.Array();
             return fromByteChunks;


### PR DESCRIPTION
Problem\n- Creating an AppImage was writing intermediate artifacts to the Desktop via hardcoded absolute paths: /home/jmn/Escritorio/Runtime{i}-... and /home/jmn/Escritorio/Image{i}-Container.sqfs.\n- This polluted the user’s Desktop and ignored XDG settings.\n\nRoot cause\n- Two debug writes were hardcoded in AppImageExtensions.ToByteSource. This did not depend on XDG_DESKTOP_DIR; it always targeted the Desktop path.\n\nFix\n- Remove hardcoded Desktop writes.\n- Introduce an opt-in debug path controlled by the environment variable DOTNETPACKAGING_DEBUG.\n  - When DOTNETPACKAGING_DEBUG is set to "1" or "true", we write the same artifacts to the OS temporary directory (System.IO.Path.GetTempPath()) instead of the Desktop.\n  - By default (env var unset), no artifacts are written.\n\nNotes\n- Uses fully qualified System.IO.Path to avoid ambiguity with Zafiro.DivineBytes.Path.\n- Behavior is now deterministic across environments and does not create unexpected files for users.\n\nHow to enable debug artifacts locally\n- bash/zsh: DOTNETPACKAGING_DEBUG=1 dotnet build\n  (debug files will appear under /tmp).\n\nThanks --base master --head fix/appimage-avoid-desktop-writes
'
'
'
'
:q
qe
'
