### PR TITLE
CLI: integrate AppImageFactory and include tool in solution

### DIFF
--- a/DotnetPackaging.sln
+++ b/DotnetPackaging.sln
@@ -35,6 +35,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zafiro.FileSystem", "libs\Z
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zafiro.FileSystem.Unix", "libs\Zafiro\src\Zafiro.FileSystem.Unix\Zafiro.FileSystem.Unix.csproj", "{02A8013F-A8B5-45D3-A32E-7A0456CFAE31}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetPackaging.Console", "src\DotnetPackaging.Console\DotnetPackaging.Console.csproj", "{C11DE8FE-8C40-44AF-BD71-50F507291E42}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -165,6 +169,18 @@ Global
 		{02A8013F-A8B5-45D3-A32E-7A0456CFAE31}.Release|x64.Build.0 = Release|Any CPU
 		{02A8013F-A8B5-45D3-A32E-7A0456CFAE31}.Release|x86.ActiveCfg = Release|Any CPU
 		{02A8013F-A8B5-45D3-A32E-7A0456CFAE31}.Release|x86.Build.0 = Release|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Debug|x64.Build.0 = Debug|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Debug|x86.Build.0 = Debug|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Release|x64.ActiveCfg = Release|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Release|x64.Build.0 = Release|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Release|x86.ActiveCfg = Release|Any CPU
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -176,6 +192,7 @@ Global
 		{7E065679-6F0F-4E28-9407-38864E1981EE} = {11CA6C64-B615-4D72-9D46-2439E7B86B87}
 		{30AB08D3-0C98-48A5-A08D-AF386E9D5E11} = {11CA6C64-B615-4D72-9D46-2439E7B86B87}
 		{02A8013F-A8B5-45D3-A32E-7A0456CFAE31} = {11CA6C64-B615-4D72-9D46-2439E7B86B87}
+		{C11DE8FE-8C40-44AF-BD71-50F507291E42} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D869DF1-9147-472D-A3D9-D519518A6951}


### PR DESCRIPTION
Summary
- Replace obsolete AppImage.From() with AppImageFactory + metadata mapping from CLI options
- Write AppImage directly using IByteSource.WriteTo
- Simplify --icon parsing (defer to internal auto-detection)
- Add DotnetPackaging.Console to DotnetPackaging.sln so CI packs the tool

Validation
- Solution builds in Release locally
- Verified CLI creates AppImage and Deb from a dotnet publish directory

CI
- azure-pipelines.yml uses DotnetDeployer.Tool to pack and push NuGet packages on master. This will include the CLI tool (PackAsTool=true).