### PR TITLE
Docs: expand WARP.md with packaging formats, CLI, and tests overview

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -1,6 +1,6 @@
 # WARP.md
 
-This file guides Warp (and future contributors) on how CI/CD works in this repository.
+This file guides Warp (and future contributors) on how CI/CD and packaging work in this repository.
 
 Scope: whole repository (DotnetPackaging).
 
@@ -31,3 +31,68 @@ Local replication
 Notes
 - Because the CLI is a dotnet tool (PackAsTool=true) and is included in the solution, CI will pack and publish it to NuGet alongside the libraries when running on master.
 - The pipeline performs a shallow fetch depth override (full history) to ensure GitVersion/describe work correctly.
+
+Packaging formats: status and details
+- AppImage (Linux)
+  - Status: supported and used. Library: src/DotnetPackaging.AppImage (net8.0).
+  - How it works: builds an AppDir from a published app directory, generates AppRun, .desktop and AppStream files, discovers icons, then creates a SquashFS and concatenates the official AppImage runtime.
+  - Runtime retrieval: downloads AppImageKit runtime per architecture (x86_64/armhf/aarch64) via RuntimeFactory. No external tools required (no linuxdeploy, no appimagetool).
+  - Icon strategy: automatic discovery under the provided directory; if none, falls back to common names (icon.svg, icon-256.png, icon.png). Optionally writes .DirIcon.
+  - Debugging: set DOTNETPACKAGING_DEBUG=1 to dump intermediate Runtime*.runtime and Image*-Container.sqfs in the temp folder.
+- Debian .deb (Linux)
+  - Status: supported and used. Library: src/DotnetPackaging.Deb.
+  - How it works: lays out files under /opt/<package>, generates .desktop under /usr/local/share/applications and a wrapper under /usr/local/bin/<package>.
+  - Packaging: fully managed (no external dpkg-deb required). Icons are optionally embedded under hicolor/<size>/apps/<package>.png.
+- MSIX (Windows)
+  - Status: experimental/preview. Library: src/DotnetPackaging.Msix with tests in src/DotnetPackaging.Msix.Tests.
+  - Validation: tests unpack resulting MSIX using makeappx tooling in CI-like conditions; end-to-end CLI exposure pending (see TODOs below).
+
+CLI tool (dotnet tool)
+- Project: src/DotnetPackaging.Console (PackAsTool=true, ToolCommandName=dotnetpackaging).
+- Commands available:
+  - appimage: create an AppImage from a directory (typically dotnet publish output). Autodetects executable + architecture; generates metadata and icons.
+  - deb: create a .deb from a directory (dotnet publish output). Detects executable; generates metadata, .desktop and wrapper.
+- Common options (both commands):
+  - --directory <dir> (required): input directory to package from.
+  - --output <file> (required): output file (.AppImage or .deb).
+  - --application-name, --wm-class, --main-category, --additional-categories, --keywords, --comment, --version,
+    --homepage, --license, --screenshot-urls, --summary, --appId, --executable-name, --is-terminal, --icon <path>.
+- Examples (from a published folder):
+  - AppImage: dotnetpackaging appimage --directory /path/to/publish --output /path/out/MyApp.AppImage --application-name "MyApp"
+  - Deb:      dotnetpackaging deb      --directory /path/to/publish --output /path/out/myapp_1.0.0_amd64.deb --application-name "MyApp"
+- CLI scope (current): appimage and deb. MSIX is not yet exposed as a CLI command.
+
+Tests
+- AppImage tests (test/DotnetPackaging.AppImage.Tests):
+  - CreateAppImage validates building from containers and saving bytes.
+  - SquashFS tests ensure filesystem construction integrity.
+- Deb tests (test/DotnetPackaging.Deb.Tests):
+  - Integration tests covering metadata and tar entries layout.
+- MSIX tests (src/DotnetPackaging.Msix.Tests):
+  - Validate building MSIX and unpacking with makeappx to assert structure.
+- Gaps / TODOs:
+  - Add CLI end-to-end tests (invocation of dotnetpackaging appimage/deb on temp publishes and validating outputs).
+  - Integrate dotnet test into azure-pipelines.yml (currently only packaging/publish runs).
+  - Expose msix in CLI and add corresponding tests.
+
+Developer workflow tips
+- Publish input
+  - AppImage/Deb consume a folder produced by dotnet publish. Both framework-dependent and self-contained outputs are supported; self-contained tends to be more robust (fewer runtime surprises), but produces larger images.
+  - For AppImage, ensure an ELF executable is present (self-contained single-file publish is acceptable). If not specified, the first eligible ELF is chosen.
+- Icon handling
+  - The CLI and libraries attempt to discover icons automatically. You can override via --icon or supply common names in the root (icon.svg, icon-256.png, icon.png).
+- Debug
+  - Set DOTNETPACKAGING_DEBUG=1 to dump AppImage intermediate artifacts (runtime + squashfs).
+
+Repository map (relevant)
+- src/DotnetPackaging.AppImage: AppImage core (AppImageFactory, RuntimeFactory, SquashFS).
+- src/DotnetPackaging.Deb: Debian packaging (Tar entries, DebFile).
+- src/DotnetPackaging.Msix: MSIX packaging (builder and helpers).
+- src/DotnetPackaging.Console: CLI (dotnet tool) with commands appimage and deb.
+- test/*: AppImage and Deb tests; src/DotnetPackaging.Msix.Tests for MSIX validation.
+
+Backlog / Future work
+- Expose msix as a first-class command in the CLI.
+- Add CLI E2E tests and hook dotnet test in CI.
+- Optional: enrich icon detection strategies and metadata mapping (e.g., auto-appId from name + reverse DNS).
+- Optional: support additional formats (e.g., rpm) if needed.


### PR DESCRIPTION
Summary
- Expand WARP.md to cover packaging formats status (.deb, .AppImage, .MSIX)
- Document CLI (dotnetpackaging) commands, common options and examples
- List available tests and current gaps (missing CLI E2E tests, CI test step)
- Add developer workflow notes, repo map and backlog

CI/Release
- Reminder: merging PRs to master publishes packages using GitVersion via DotnetDeployer.
