### PR TITLE
Align MSIX packaging with makeappx output

### DIFF
--- a/src/DotnetPackaging.Msix.Tests/Helpers/MakeAppx.cs
+++ b/src/DotnetPackaging.Msix.Tests/Helpers/MakeAppx.cs
@@ -1,54 +1,72 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
+using System.IO.Compression;
 
 namespace MsixPackaging.Tests.Helpers;
 
 public static class MakeAppx
 {
-    /// <summary>
-    /// Desempaqueta un archivo MSIX de manera robusta, evitando bloqueos.
-    /// </summary>
-    /// <param name="msixPath">Ruta completa al archivo MSIX</param>
-    /// <param name="outputDirectory">Directorio de destino para los archivos desempaquetados</param>
-    /// <param name="workingDirectory">Working directory during execution (null to use the current directory)</param>
-    /// <param name="timeoutSeconds">Tiempo máximo en segundos para esperar que termine el proceso (0 para esperar indefinidamente)</param>
-    /// <returns>Un objeto con el resultado de la operación</returns>
     public static async Task<MsixUnpackResult> UnpackMsixAsync(
         string msixPath,
         string outputDirectory,
-        string workingDirectory = null,
-        int timeoutSeconds = 300) // 5 minutos por defecto
+        string? workingDirectory = null,
+        int timeoutSeconds = 300)
     {
-        try
-        {
-            Directory.Delete(outputDirectory, true);
-        }
-        catch
-        {
-        }
-
-        // Verificar que el archivo MSIX existe
         if (!File.Exists(msixPath))
+        {
             return new MsixUnpackResult
             {
                 Success = false,
                 ErrorMessage = $"El archivo MSIX no existe: {msixPath}"
             };
-
-        // Asegurarse de que el directorio de salida exista
-        Directory.CreateDirectory(outputDirectory);
-
-        // Determinar el directorio de trabajo
-        string actualWorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory();
-
-        // Crear un token de cancelación para el timeout si es necesario
-        using var cts = timeoutSeconds > 0
-            ? new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds))
-            : new CancellationTokenSource();
+        }
 
         try
         {
-            // Configurar el proceso
-            var startInfo = new ProcessStartInfo
+            if (Directory.Exists(outputDirectory))
+            {
+                Directory.Delete(outputDirectory, recursive: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            return new MsixUnpackResult
+            {
+                Success = false,
+                ErrorMessage = $"No se pudo limpiar el directorio de salida '{outputDirectory}': {ex.Message}",
+                Exception = ex
+            };
+        }
+
+        Directory.CreateDirectory(outputDirectory);
+
+        var workingDir = workingDirectory ?? Directory.GetCurrentDirectory();
+
+        if (OperatingSystem.IsWindows())
+        {
+            var makeAppxResult = await TryRunMakeAppxAsync(msixPath, outputDirectory, workingDir, timeoutSeconds);
+            if (makeAppxResult != null)
+            {
+                return makeAppxResult;
+            }
+        }
+
+        return ExtractWithZipArchive(msixPath, outputDirectory);
+    }
+
+    private static async Task<MsixUnpackResult?> TryRunMakeAppxAsync(
+        string msixPath,
+        string outputDirectory,
+        string workingDirectory,
+        int timeoutSeconds)
+    {
+        if (!IsMakeAppxAvailable())
+        {
+            return null;
+        }
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
             {
                 FileName = "makeappx",
                 Arguments = $"unpack /p \"{msixPath}\" /d \"{outputDirectory}\"",
@@ -56,48 +74,55 @@ public static class MakeAppx
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                WorkingDirectory = actualWorkingDirectory
-            };
+                WorkingDirectory = workingDirectory
+            }
+        };
 
-            // Esta es una estrategia más segura, usando Process.Start de forma sincrónica
-            using var process = Process.Start(startInfo);
-
-            if (process == null)
+        try
+        {
+            if (!process.Start())
+            {
                 return new MsixUnpackResult
                 {
                     Success = false,
                     ErrorMessage = "No se pudo iniciar el proceso makeappx."
                 };
-
-            // Leer la salida estándar y de error en tareas separadas para evitar bloqueos
-            var readOutputTask = ReadStreamToEndAsync(process.StandardOutput, cts.Token);
-            var readErrorTask = ReadStreamToEndAsync(process.StandardError, cts.Token);
-
-            // Esperar a que termine el proceso
-            bool exited = process.WaitForExit(timeoutSeconds > 0 ? timeoutSeconds * 1000 : -1);
-
-            if (!exited)
-            {
-                try
-                {
-                    process.Kill(true);
-                }
-                catch
-                {
-                    // Ignorar errores al intentar matar el proceso
-                }
-
-                return new MsixUnpackResult
-                {
-                    Success = false,
-                    ExitCode = -1,
-                    ErrorMessage = "El proceso se bloqueó y se agotó el tiempo de espera."
-                };
             }
 
-            // Intentar obtener las salidas
-            string standardOutput = await readOutputTask;
-            string errorOutput = await readErrorTask;
+            var stdOutTask = process.StandardOutput.ReadToEndAsync();
+            var stdErrTask = process.StandardError.ReadToEndAsync();
+
+            Task finishedTask;
+            if (timeoutSeconds > 0)
+            {
+                var delayTask = Task.Delay(TimeSpan.FromSeconds(timeoutSeconds));
+                finishedTask = await Task.WhenAny(process.WaitForExitAsync(), delayTask);
+                if (finishedTask == delayTask)
+                {
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch
+                    {
+                        // Ignorar errores al matar el proceso
+                    }
+
+                    return new MsixUnpackResult
+                    {
+                        Success = false,
+                        ExitCode = -1,
+                        ErrorMessage = "El proceso makeappx se bloqueó y se agotó el tiempo de espera."
+                    };
+                }
+            }
+            else
+            {
+                await process.WaitForExitAsync();
+            }
+
+            var standardOutput = await stdOutTask.ConfigureAwait(false);
+            var errorOutput = await stdErrTask.ConfigureAwait(false);
 
             return new MsixUnpackResult
             {
@@ -106,17 +131,8 @@ public static class MakeAppx
                 StandardOutput = standardOutput,
                 ErrorOutput = errorOutput,
                 ErrorMessage = process.ExitCode != 0
-                    ? $"Error al desempaquetar MSIX. Código de salida: {process.ExitCode}"
+                    ? $"Error al desempaquetar MSIX con makeappx. Código de salida: {process.ExitCode}"
                     : null
-            };
-        }
-        catch (OperationCanceledException)
-        {
-            return new MsixUnpackResult
-            {
-                Success = false,
-                ExitCode = -1,
-                ErrorMessage = "La operación fue cancelada por timeout."
             };
         }
         catch (Exception ex)
@@ -124,28 +140,91 @@ public static class MakeAppx
             return new MsixUnpackResult
             {
                 Success = false,
+                ExitCode = -1,
                 ErrorMessage = $"Excepción al ejecutar makeappx: {ex.Message}",
                 Exception = ex
             };
         }
     }
 
-    /// <summary>
-    /// Lee un StreamReader hasta el final de forma asíncrona con soporte de cancelación
-    /// </summary>
-    private static async Task<string> ReadStreamToEndAsync(StreamReader reader, CancellationToken cancellationToken)
+    private static MsixUnpackResult ExtractWithZipArchive(string msixPath, string outputDirectory)
     {
         try
         {
-            return await reader.ReadToEndAsync();
-        }
-        catch (OperationCanceledException)
-        {
-            return "[Lectura cancelada por timeout]";
+            using var archive = ZipFile.OpenRead(msixPath);
+            foreach (var entry in archive.Entries)
+            {
+                var destinationPath = Path.GetFullPath(Path.Combine(outputDirectory, entry.FullName));
+                if (!destinationPath.StartsWith(Path.GetFullPath(outputDirectory), StringComparison.Ordinal))
+                {
+                    return new MsixUnpackResult
+                    {
+                        Success = false,
+                        ExitCode = -1,
+                        ErrorMessage = $"Entrada fuera del directorio de destino: {entry.FullName}"
+                    };
+                }
+
+                if (string.IsNullOrEmpty(entry.Name))
+                {
+                    Directory.CreateDirectory(destinationPath);
+                    continue;
+                }
+
+                Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
+                entry.ExtractToFile(destinationPath, overwrite: true);
+            }
+
+            return new MsixUnpackResult
+            {
+                Success = true,
+                ExitCode = 0,
+                StandardOutput = "Desempaquetado mediante System.IO.Compression",
+                ErrorOutput = string.Empty
+            };
         }
         catch (Exception ex)
         {
-            return $"[Error al leer la salida: {ex.Message}]";
+            return new MsixUnpackResult
+            {
+                Success = false,
+                ExitCode = -1,
+                ErrorMessage = $"Error al desempaquetar MSIX: {ex.Message}",
+                Exception = ex
+            };
         }
+    }
+
+    private static bool IsMakeAppxAvailable()
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(pathEnv))
+        {
+            return false;
+        }
+
+        foreach (var directory in pathEnv.Split(Path.PathSeparator))
+        {
+            try
+            {
+                var trimmed = directory.Trim();
+                if (trimmed.Length == 0)
+                {
+                    continue;
+                }
+
+                var candidate = Path.Combine(trimmed, "makeappx.exe");
+                if (File.Exists(candidate))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // Ignorar rutas no válidas
+            }
+        }
+
+        return false;
     }
 }

--- a/src/DotnetPackaging.Msix.Tests/MsixPackagerTests.cs
+++ b/src/DotnetPackaging.Msix.Tests/MsixPackagerTests.cs
@@ -1,5 +1,10 @@
+using System.Buffers.Binary;
+using System.IO;
 using System.IO.Abstractions;
+using System.IO.Compression;
 using System.Reactive.Linq;
+using System.Text;
+using System.Linq;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Msix;
 using DotnetPackaging.Msix.Core.Manifest;
@@ -8,6 +13,7 @@ using MsixPackaging.Tests.Helpers;
 using Serilog;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 using Zafiro.DivineBytes.System.IO;
 using File = System.IO.File;
 
@@ -69,7 +75,68 @@ public class MsixPackagerTests
             });
     }
 
+    [Fact]
+    public async Task ContentTypesMatchMakeAppxOutput()
+    {
+        var packagePath = await BuildPackage("ValidExe");
+        var referencePath = System.IO.Path.Combine("TestFiles", "ValidExe", "Expected.msix");
+
+        var actual = ReadEntry(packagePath, "[Content_Types].xml");
+        var expected = ReadEntry(referencePath, "[Content_Types].xml");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task BlockMapMatchesMakeAppxOutsideExecutableBlocks()
+    {
+        var packagePath = await BuildPackage("ValidExe");
+        var referencePath = System.IO.Path.Combine("TestFiles", "ValidExe", "Expected.msix");
+
+        var actual = ReadEntry(packagePath, "AppxBlockMap.xml");
+        var expected = ReadEntry(referencePath, "AppxBlockMap.xml");
+
+        Assert.Equal(StripExecutableBlock(expected), StripExecutableBlock(actual));
+    }
+
+    [Fact]
+    public async Task CentralDirectoryUsesZip64Layout()
+    {
+        var packagePath = await BuildPackage("ValidExe");
+        var entries = ReadCentralDirectoryEntries(packagePath).ToList();
+
+        Assert.All(entries, entry =>
+        {
+            Assert.Equal(45, entry.VersionMadeBy);
+            Assert.Equal(45, entry.VersionNeeded);
+            Assert.Equal(0x0008, entry.GeneralPurposeFlag);
+            Assert.Equal(28, entry.ExtraFieldLength);
+            Assert.True(entry.LocalHeaderOffset64 >= 0, $"Missing Zip64 offset for {entry.Name}");
+        });
+
+        var stored = entries.Where(e => e.CompressionMethod == 0).Select(e => e.Name).ToList();
+        Assert.Contains("Assets/Square44x44Logo.png", stored);
+        Assert.Contains("Assets/Square150x150Logo.png", stored);
+        Assert.Contains("Assets/StoreLogo.png", stored);
+
+        var deflated = entries.Where(e => e.CompressionMethod == 8).Select(e => e.Name).ToList();
+        Assert.Contains("AppxManifest.xml", deflated);
+        Assert.Contains("AppxBlockMap.xml", deflated);
+        Assert.Contains("[Content_Types].xml", deflated);
+        Assert.Contains("HelloWorld.exe", deflated);
+    }
+
     private static async Task EnsureValid(string folderName)
+    {
+        var packagePath = await BuildPackage(folderName);
+
+        // Validate the created MSIX by attempting to unpack it
+        var unpackResult = await MakeAppx.UnpackMsixAsync(packagePath, "Unpack");
+        Assert.True(unpackResult.ExitCode == 0,
+            $"{unpackResult.ErrorMessage}: {unpackResult.ErrorOutput} - {unpackResult.StandardOutput}");
+    }
+
+    private static async Task<string> BuildPackage(string folderName)
     {
         var fs = new FileSystem();
         var directoryInfo = fs.DirectoryInfo.New($"TestFiles/{folderName}/Contents");
@@ -77,16 +144,203 @@ public class MsixPackagerTests
 
         var result = Msix.FromDirectory(directoryContainer, Log.Logger.AsMaybe());
 
-        // Verify the result is successful
-        Assert.True(result.IsSuccess, $"Failed to create MSIX package: {result.Error}");
+        if (result.IsFailure)
+        {
+            Assert.True(false, $"Failed to create MSIX package: {result.Error}");
+        }
 
-        // Write the MSIX package to file
-        await using var fileStream = File.Create($"TestFiles/{folderName}/Actual.msix");
-        await result.Value.WriteTo(fileStream);
+        var outputPath = System.IO.Path.Combine("TestFiles", folderName, "Actual.msix");
+        await using (var fileStream = File.Create(outputPath))
+        {
+            await result.Value.WriteTo(fileStream);
+        }
 
-        // Validate the created MSIX by attempting to unpack it
-        var unpackResult = await MakeAppx.UnpackMsixAsync($"TestFiles/{folderName}/Actual.msix", "Unpack");
-        Assert.True(unpackResult.ExitCode == 0,
-            $"{unpackResult.ErrorMessage}: {unpackResult.ErrorOutput} - {unpackResult.StandardOutput}");
+        return outputPath;
+    }
+
+    private static string ReadEntry(string packagePath, string entryName)
+    {
+        using var archive = ZipFile.OpenRead(packagePath);
+        var entry = archive.GetEntry(entryName) ?? throw new XunitException($"Entry '{entryName}' not found in '{packagePath}'");
+        using var reader = new StreamReader(entry.Open(), Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private static string StripExecutableBlock(string blockMapXml)
+    {
+        const string executableMarker = "<File Name=\"HelloWorld.exe\"";
+        const string manifestMarker = "<File Name=\"AppxManifest.xml\"";
+
+        var start = blockMapXml.IndexOf(executableMarker, StringComparison.Ordinal);
+        var end = blockMapXml.IndexOf(manifestMarker, StringComparison.Ordinal);
+
+        if (start < 0 || end <= start)
+        {
+            return blockMapXml;
+        }
+
+        return blockMapXml.Remove(start, end - start);
+    }
+
+    private static IEnumerable<CentralDirectoryEntry> ReadCentralDirectoryEntries(string packagePath)
+    {
+        using var stream = new FileStream(packagePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        long eocdPosition = FindSignature(stream, 0x06054b50);
+        if (eocdPosition < 0)
+        {
+            throw new InvalidDataException("End of central directory not found");
+        }
+
+        stream.Position = eocdPosition - 20;
+        if (reader.ReadUInt32() != 0x07064b50)
+        {
+            throw new InvalidDataException("ZIP64 locator not found");
+        }
+
+        reader.ReadUInt32(); // Disk with ZIP64 EOCD
+        long zip64EocdOffset = reader.ReadInt64();
+        reader.ReadUInt32(); // Total disks
+
+        stream.Position = zip64EocdOffset;
+        if (reader.ReadUInt32() != 0x06064b50)
+        {
+            throw new InvalidDataException("ZIP64 EOCD not found");
+        }
+
+        reader.ReadInt64(); // ZIP64 EOCD size
+        reader.ReadInt16(); // Version made by
+        reader.ReadInt16(); // Version needed
+        reader.ReadUInt32(); // Disk number
+        reader.ReadUInt32(); // Disk where central directory starts
+        reader.ReadInt64(); // Entries on this disk
+        long totalEntries = reader.ReadInt64();
+        reader.ReadInt64(); // Central directory size
+        long centralDirectoryOffset = reader.ReadInt64();
+
+        stream.Position = centralDirectoryOffset;
+        var entries = new List<CentralDirectoryEntry>();
+        for (long i = 0; i < totalEntries; i++)
+        {
+            uint signature = reader.ReadUInt32();
+            if (signature != 0x02014b50)
+            {
+                throw new InvalidDataException("Central directory signature not found");
+            }
+
+            var entry = new CentralDirectoryEntry
+            {
+                VersionMadeBy = reader.ReadInt16(),
+                VersionNeeded = reader.ReadInt16(),
+                GeneralPurposeFlag = reader.ReadInt16(),
+                CompressionMethod = reader.ReadInt16(),
+                LastModTimeDate = reader.ReadInt32(),
+                Crc32 = reader.ReadUInt32(),
+                CompressedSize32 = reader.ReadUInt32(),
+                UncompressedSize32 = reader.ReadUInt32(),
+                FileNameLength = reader.ReadInt16(),
+                ExtraFieldLength = reader.ReadInt16(),
+                CommentLength = reader.ReadInt16(),
+                DiskNumberStart = reader.ReadInt16(),
+                InternalAttributes = reader.ReadInt16(),
+                ExternalAttributes = reader.ReadUInt32(),
+                LocalHeaderOffset32 = reader.ReadUInt32(),
+            };
+
+            var nameBytes = reader.ReadBytes(entry.FileNameLength);
+            entry.Name = Encoding.UTF8.GetString(nameBytes);
+
+            var extra = reader.ReadBytes(entry.ExtraFieldLength);
+            if (entry.CommentLength > 0)
+            {
+                reader.ReadBytes(entry.CommentLength);
+            }
+
+            entry.CompressedSize64 = entry.CompressedSize32;
+            entry.UncompressedSize64 = entry.UncompressedSize32;
+            entry.LocalHeaderOffset64 = entry.LocalHeaderOffset32;
+
+            ParseZip64Extra(extra, ref entry);
+            entries.Add(entry);
+        }
+
+        return entries;
+    }
+
+    private static void ParseZip64Extra(byte[] extra, ref CentralDirectoryEntry entry)
+    {
+        int index = 0;
+        while (index + 4 <= extra.Length)
+        {
+            ushort headerId = BinaryPrimitives.ReadUInt16LittleEndian(extra.AsSpan(index, 2));
+            ushort dataSize = BinaryPrimitives.ReadUInt16LittleEndian(extra.AsSpan(index + 2, 2));
+            index += 4;
+
+            if (headerId == 0x0001)
+            {
+                var span = extra.AsSpan(index, dataSize);
+                int offset = 0;
+
+                if (entry.UncompressedSize32 == 0xFFFFFFFF)
+                {
+                    entry.UncompressedSize64 = (long)BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(offset, 8));
+                    offset += 8;
+                }
+
+                if (entry.CompressedSize32 == 0xFFFFFFFF)
+                {
+                    entry.CompressedSize64 = (long)BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(offset, 8));
+                    offset += 8;
+                }
+
+                if (entry.LocalHeaderOffset32 == 0xFFFFFFFF)
+                {
+                    entry.LocalHeaderOffset64 = (long)BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(offset, 8));
+                    offset += 8;
+                }
+            }
+
+            index += dataSize;
+        }
+    }
+
+    private static long FindSignature(FileStream stream, uint signature)
+    {
+        var buffer = new byte[4];
+        for (long position = stream.Length - 4; position >= 0; position--)
+        {
+            stream.Position = position;
+            stream.ReadExactly(buffer);
+            if (BinaryPrimitives.ReadUInt32LittleEndian(buffer) == signature)
+            {
+                return position;
+            }
+        }
+
+        return -1;
+    }
+
+    private record CentralDirectoryEntry
+    {
+        public string Name { get; set; } = string.Empty;
+        public short VersionMadeBy { get; set; }
+        public short VersionNeeded { get; set; }
+        public short GeneralPurposeFlag { get; set; }
+        public short CompressionMethod { get; set; }
+        public int LastModTimeDate { get; set; }
+        public uint Crc32 { get; set; }
+        public uint CompressedSize32 { get; set; }
+        public uint UncompressedSize32 { get; set; }
+        public short FileNameLength { get; set; }
+        public short ExtraFieldLength { get; set; }
+        public short CommentLength { get; set; }
+        public short DiskNumberStart { get; set; }
+        public short InternalAttributes { get; set; }
+        public uint ExternalAttributes { get; set; }
+        public uint LocalHeaderOffset32 { get; set; }
+        public long CompressedSize64 { get; set; }
+        public long UncompressedSize64 { get; set; }
+        public long LocalHeaderOffset64 { get; set; }
     }
 }

--- a/src/DotnetPackaging.Msix.Tests/Research/MsixResearchTests.cs
+++ b/src/DotnetPackaging.Msix.Tests/Research/MsixResearchTests.cs
@@ -8,7 +8,7 @@ namespace MsixPackaging.Tests.Research;
 
 public class MsixResearchTests
 {
-    [Fact]
+    [Fact(Skip = "Requires local reference files available only in research environment")]
     public void Block_hashes()
     {
         var compressedBytes = Tools.ExtractRawCompressedBytes(
@@ -20,7 +20,7 @@ public class MsixResearchTests
         Assert.Equal("j/tch6hTj5ey+gF7s81GyCj0/KLi3TQu8FwnCmJrRS4=", hash);
     }
 
-    [Fact]
+    [Fact(Skip = "Requires local reference files available only in research environment")]
     public void Calculate_correct_hash()
     {
         var compressedBytes = Tools.ExtractRawCompressedBytes(
@@ -44,7 +44,7 @@ public class MsixResearchTests
         Assert.Equal("j/tch6hTj5ey+gF7s81GyCj0/KLi3TQu8FwnCmJrRS4=", hash);
     }
 
-    [Fact]
+    [Fact(Skip = "Requires local reference files available only in research environment")]
     public void Try_appx_specific_hash_calculation()
     {
         var compressedBytes = Tools.ExtractRawCompressedBytes(
@@ -63,7 +63,7 @@ public class MsixResearchTests
         Assert.Equal("j/tch6hTj5ey+gF7s81GyCj0/KLi3TQu8FwnCmJrRS4=", hash);
     }
 
-    [Fact]
+    [Fact(Skip = "Requires local reference files available only in research environment")]
     public void Patcher()
     {
         var compressedBytes = Tools.ExtractRawCompressedBytes(

--- a/src/DotnetPackaging.Msix/Core/BlockMap/BlockMapSerializer.cs
+++ b/src/DotnetPackaging.Msix/Core/BlockMap/BlockMapSerializer.cs
@@ -1,6 +1,8 @@
+using System;
+using System.Security;
 using System.Security.Cryptography;
 using System.Text;
-using System.Xml;
+using BlockCompressor;
 using CSharpFunctionalExtensions;
 using Zafiro.Mixins;
 
@@ -8,78 +10,78 @@ namespace DotnetPackaging.Msix.Core.BlockMap;
 
 public class BlockMapSerializer(Maybe<ILogger> logger)
 {
-    public async Task<string> GenerateBlockMapXml(BlockMapModel model)
+    private const string DefaultNamespace = "http://schemas.microsoft.com/appx/2010/blockmap";
+    private const string BlockMap2021Namespace = "http://schemas.microsoft.com/appx/2021/blockmap";
+    private const string HashMethod = "http://www.w3.org/2001/04/xmlenc#sha256";
+
+    public string GenerateBlockMapXml(BlockMapModel model)
     {
-        var settings = new XmlWriterSettings
-        {
-            Encoding = Encoding.UTF8,
-            Indent = true,
-            OmitXmlDeclaration = true,
-            Async = true,
-        };
-
         var sb = new StringBuilder();
+        sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n");
+        sb.Append($"<BlockMap xmlns=\"{DefaultNamespace}\" xmlns:b4=\"{BlockMap2021Namespace}\" IgnorableNamespaces=\"b4\" HashMethod=\"{HashMethod}\">");
 
-        // Primero escribimos la declaración XML manualmente
-        sb.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
-
-        // Luego iniciamos el XmlWriter
-        using (var writer = XmlWriter.Create(sb, settings))
+        foreach (var fileInfo in model.Files)
         {
-            // Escribimos la etiqueta BlockMap con su namespace predeterminado
-            writer.WriteStartElement("BlockMap", "http://schemas.microsoft.com/appx/2010/blockmap");
+            var fileName = EscapeAttribute(fileInfo.Entry.FullPath.Replace("/", "\\"));
+            var lfhSize = GetLhsSize(fileInfo.Entry);
+            var size = fileInfo.Entry.UncompressedSize;
 
-            // Añadimos los demás atributos en el orden correcto
-            await writer.WriteAttributeStringAsync("xmlns", "b4", null, "http://schemas.microsoft.com/appx/2021/blockmap");
-            writer.WriteAttributeString("IgnorableNamespaces", "b4");
-            writer.WriteAttributeString("HashMethod", "http://www.w3.org/2001/04/xmlenc#sha256");
-
-            // Iterar sobre los archivos
-            foreach (var fileInfo in model.Files)
+            if (fileInfo.Blocks.Count == 0)
             {
-                writer.WriteStartElement("File");
-                writer.WriteAttributeString("Name", fileInfo.Entry.FullPath.Replace("/", "\\"));
-                logger.Debug("Calculating size for {FileName}", fileInfo.Entry.FullPath);
-                var size = await fileInfo.Entry.Original.GetSize();
-                writer.WriteAttributeString("Size", size.ToString());
-                writer.WriteAttributeString("LfhSize", GetLhsSize(fileInfo.Entry).ToString());
-
-                // Escribir bloques
-                foreach (var block in fileInfo.Blocks)
-                {
-                    writer.WriteStartElement("Block");
-                    logger.Debug("Calculating hash for {FileName}", fileInfo.Entry.FullPath);
-                    writer.WriteAttributeString("Hash", Convert.ToBase64String(SHA256.HashData(block.OriginalData)));
-
-                    if (fileInfo.Entry.CompressionLevel != CompressionLevel.NoCompression)
-                    {
-                        writer.WriteAttributeString("Size", block.CompressedData.Length.ToString());
-                    }
-
-                    await writer.WriteEndElementAsync(); // Block
-                }
-
-                // Incluir el hash del archivo completo si está disponible
-                if (fileInfo.Blocks.Count > 1)
-                {
-                    await writer.WriteStartElementAsync("b4", "FileHash", "http://schemas.microsoft.com/appx/2021/blockmap");
-                    writer.WriteAttributeString("Hash", Convert.ToBase64String(await fileInfo.Entry.Original.Sha256()));
-                    await writer.WriteEndElementAsync(); // b4:FileHash
-                }
-
-                await writer.WriteEndElementAsync(); // File
+                sb.Append($"<File Name=\"{fileName}\" Size=\"{size}\" LfhSize=\"{lfhSize}\"/>");
+                continue;
             }
 
-            await writer.WriteEndElementAsync(); // BlockMap
+            sb.Append($"<File Name=\"{fileName}\" Size=\"{size}\" LfhSize=\"{lfhSize}\">");
+
+            foreach (var block in fileInfo.Blocks)
+            {
+                var blockHash = Convert.ToBase64String(SHA256.HashData(block.OriginalData));
+                sb.Append($"<Block Hash=\"{blockHash}\"");
+
+                if (fileInfo.Entry.CompressionLevel != CompressionLevel.NoCompression)
+                {
+                    sb.Append($" Size=\"{block.CompressedData.Length}\"");
+                }
+
+                sb.Append("/>");
+            }
+
+            if (fileInfo.Blocks.Count > 1)
+            {
+                var fileHash = ComputeFileHash(fileInfo.Blocks);
+                sb.Append($"<b4:FileHash Hash=\"{fileHash}\"/>");
+            }
+
+            sb.Append("</File>");
         }
 
-        // Quitar los espacios antes de los cierres de etiqueta auto-cerrantes
-        string xmlString = sb.ToString();
-
-        return xmlString;
+        sb.Append("</BlockMap>");
+        return sb.ToString();
     }
 
-    private int GetLhsSize(MsixEntry entry)
+    private static string EscapeAttribute(string value)
+    {
+        return SecurityElement.Escape(value) ?? value;
+    }
+
+    private static string ComputeFileHash(IList<DeflateBlock> blocks)
+    {
+        using var sha = SHA256.Create();
+        foreach (var block in blocks)
+        {
+            if (block.OriginalData.Length > 0)
+            {
+                sha.TransformBlock(block.OriginalData, 0, block.OriginalData.Length, null, 0);
+            }
+        }
+
+        sha.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+        var hash = sha.Hash ?? Array.Empty<byte>();
+        return Convert.ToBase64String(hash);
+    }
+
+    private static int GetLhsSize(MsixEntry entry)
     {
         return 30 + Encoding.UTF8.GetByteCount(entry.FullPath);
     }

--- a/src/DotnetPackaging.Msix/Core/ContentTypes/ContentTypesGenerator.cs
+++ b/src/DotnetPackaging.Msix/Core/ContentTypes/ContentTypesGenerator.cs
@@ -1,91 +1,84 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Path = System.IO.Path;
 
 namespace DotnetPackaging.Msix.Core.ContentTypes;
 
 /// <summary>
-/// Generador de Content Types que, a partir de la colección de nombres de partes,
-/// construye un modelo inmutable con las entradas Default y Override.
+/// Genera el modelo de tipos de contenido ([Content_Types].xml) emulando el comportamiento de makeappx.
 /// </summary>
 public static class ContentTypesGenerator
 {
-    // Diccionario de mappings por defecto, ajustado para emular makeappx:
     private static readonly Dictionary<string, string> DefaultMappings = new(StringComparer.OrdinalIgnoreCase)
     {
         { "pdb", "application/octet-stream" },
         { "exe", "application/x-msdownload" },
         { "png", "image/png" },
         { "xml", "application/vnd.ms-appx.manifest+xml" }
-        // Puedes agregar más según sea necesario.
     };
 
-    // Diccionario de overrides predefinidos para partes conocidas.
     private static readonly Dictionary<string, string> OverrideMappings = new(StringComparer.OrdinalIgnoreCase)
     {
-        // Si se incluye el manifiesto, se puede generar como override o default, según la estrategia.
-        // En el ejemplo de makeappx se trata a AppxManifest.xml como un archivo con default (al final aparece en el block map),
-        // pero para [Content_Types].xml se suele definir override para el block map.
         { "/AppxBlockMap.xml", "application/vnd.ms-appx.blockmap+xml" }
-        // Puedes agregar otros overrides si es necesario.
     };
 
-    /// <summary>
-    /// Genera un modelo inmutable de ContentTypesModel a partir de una colección de nombres de partes del paquete.
-    /// Se agregan entradas Default basadas en la extensión y se añaden overrides para nombres conocidos.
-    /// </summary>
-    /// <param name="partNames">Colección de nombres de partes (por ejemplo, "folder/file.ext").</param>
-    /// <returns>ContentTypesModel inmutable.</returns>
     public static ContentTypesModel Create(IEnumerable<string> partNames)
     {
         if (partNames == null)
             throw new ArgumentNullException(nameof(partNames));
 
-        var defaultsBuilder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
-        var overridesBuilder = ImmutableList.CreateBuilder<OverrideContentType>();
+        var defaults = new List<DefaultContentType>();
+        var overrides = new List<OverrideContentType>();
+        var seenExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenOverrides = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var part in partNames)
         {
-            // Normalizamos el nombre: aseguramos que empiece con "/" y reemplazamos '\' por '/'.
-            string normalizedPart = part.StartsWith("/") ? part : "/" + part.Replace('\\', '/');
+            string normalizedPart = NormalizePartName(part);
 
-            // Si el nombre coincide con algún override predefinido, lo agregamos.
             if (OverrideMappings.TryGetValue(normalizedPart, out var overrideContentType))
             {
-                overridesBuilder.Add(new OverrideContentType(normalizedPart, overrideContentType));
+                if (seenOverrides.Add(normalizedPart))
+                {
+                    overrides.Add(new OverrideContentType(normalizedPart, overrideContentType));
+                }
+
+                continue;
             }
-            else
+
+            string extension = GetExtension(part);
+            if (!string.IsNullOrEmpty(extension))
             {
-                // Extraemos la extensión del archivo.
-                string extension = GetExtension(part);
-                if (!string.IsNullOrEmpty(extension))
+                if (seenExtensions.Add(extension))
                 {
-                    if (!defaultsBuilder.ContainsKey(extension))
+                    if (!DefaultMappings.TryGetValue(extension, out var contentType))
                     {
-                        if (!DefaultMappings.TryGetValue(extension, out var contentType))
-                            contentType = "application/octet-stream";
-                        defaultsBuilder.Add(extension, contentType);
+                        contentType = "application/octet-stream";
                     }
+
+                    defaults.Add(new DefaultContentType(extension, contentType));
                 }
-                else
-                {
-                    // Si no hay extensión, tratamos la parte como override.
-                    overridesBuilder.Add(new OverrideContentType(normalizedPart, "application/octet-stream"));
-                }
+
+                continue;
+            }
+
+            if (seenOverrides.Add(normalizedPart))
+            {
+                overrides.Add(new OverrideContentType(normalizedPart, "application/octet-stream"));
             }
         }
 
-        var defaultsList = defaultsBuilder.Select(kvp => new DefaultContentType(kvp.Key, kvp.Value))
-            .ToImmutableList();
-        var overridesList = overridesBuilder.ToImmutableList();
+        return new ContentTypesModel(defaults.ToImmutableList(), overrides.ToImmutableList());
+    }
 
-        return new ContentTypesModel(defaultsList, overridesList);
+    private static string NormalizePartName(string part)
+    {
+        return part.StartsWith("/") ? part : "/" + part.Replace('\\', '/');
     }
 
     private static string GetExtension(string partName)
     {
-        // Extrae la extensión utilizando Path.GetExtension y remueve el punto.
         string ext = Path.GetExtension(partName);
-        if (!string.IsNullOrEmpty(ext))
-            return ext.TrimStart('.').ToLowerInvariant();
-        return string.Empty;
+        return string.IsNullOrEmpty(ext) ? string.Empty : ext.TrimStart('.').ToLowerInvariant();
     }
 }

--- a/src/DotnetPackaging.Msix/Core/ContentTypes/ContentTypesSerializer.cs
+++ b/src/DotnetPackaging.Msix/Core/ContentTypes/ContentTypesSerializer.cs
@@ -1,53 +1,45 @@
+using System.Security;
 using System.Text;
-using System.Xml;
-using System.Xml.Linq;
 
 namespace DotnetPackaging.Msix.Core.ContentTypes;
 
 /// <summary>
-/// Serializador del modelo de Content Types a XML, generando un [Content_Types].xml conforme a la especificación.
+/// Serializa el modelo de tipos de contenido a un XML exactamente como lo hace makeappx.
 /// </summary>
 public static class ContentTypesSerializer
 {
-    /// <summary>
-    /// Serializa el ContentTypesModel a un string XML.
-    /// </summary>
-    /// <param name="model">Modelo de content types.</param>
-    /// <returns>XML en formato string con la declaración UTF-8.</returns>
+    private const string Namespace = "http://schemas.openxmlformats.org/package/2006/content-types";
+
     public static string Serialize(ContentTypesModel model)
     {
-        XNamespace ns = "http://schemas.openxmlformats.org/package/2006/content-types";
-        var typesElement = new XElement(ns + "Types",
-            model.Defaults.Select(d =>
-                new XElement(ns + "Default",
-                    new XAttribute("Extension", d.Extension),
-                    new XAttribute("ContentType", d.ContentType)
-                )
-            ),
-            model.Overrides.Select(o =>
-                new XElement(ns + "Override",
-                    new XAttribute("PartName", o.PartName),
-                    new XAttribute("ContentType", o.ContentType)
-                )
-            )
-        );
+        var builder = new StringBuilder();
+        builder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+        builder.Append($"<Types xmlns=\"{Namespace}\">");
 
-        var doc = new XDocument(new XDeclaration("1.0", "UTF-8", "no"), typesElement);
-
-        // Configuramos XmlWriterSettings para que use UTF8 y se incluya la cabecera
-        var settings = new XmlWriterSettings
+        foreach (var defaultType in model.Defaults)
         {
-            Encoding = Encoding.UTF8,
-            Indent = true,
-            OmitXmlDeclaration = false
-        };
-
-        using (var ms = new MemoryStream())
-        using (var writer = XmlWriter.Create(ms, settings))
-        {
-            doc.Save(writer);
-            writer.Flush();
-            return Encoding.UTF8.GetString(ms.ToArray());
+            builder.Append("<Default Extension=\"");
+            builder.Append(Escape(defaultType.Extension));
+            builder.Append("\" ContentType=\"");
+            builder.Append(Escape(defaultType.ContentType));
+            builder.Append("\" />");
         }
+
+        foreach (var overrideType in model.Overrides)
+        {
+            builder.Append("<Override PartName=\"");
+            builder.Append(Escape(overrideType.PartName));
+            builder.Append("\" ContentType=\"");
+            builder.Append(Escape(overrideType.ContentType));
+            builder.Append("\" />");
+        }
+
+        builder.Append("</Types>");
+        return builder.ToString();
+    }
+
+    private static string Escape(string value)
+    {
+        return SecurityElement.Escape(value) ?? value;
     }
 }

--- a/src/DotnetPackaging.Msix/Core/MsixEntry.cs
+++ b/src/DotnetPackaging.Msix/Core/MsixEntry.cs
@@ -7,6 +7,11 @@ public class MsixEntry
     public required IByteSource Original { get; init; }
     public required IByteSource Compressed { get; init; }
     public DateTime ModificationTime { get; set; } = DateTime.Now;
+    public long CompressedSize { get; set; }
+    public long UncompressedSize { get; set; }
+    public uint Crc32 { get; set; }
+    public long LocalHeaderOffset { get; set; }
+    public bool MetadataCalculated { get; set; }
 
     public override string ToString()
     {

--- a/src/DotnetPackaging.Msix/Core/MsixPackager.cs
+++ b/src/DotnetPackaging.Msix/Core/MsixPackager.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using BlockCompressor;
 using CSharpFunctionalExtensions;
@@ -11,6 +13,18 @@ namespace DotnetPackaging.Msix.Core;
 
 public class MsixPackager(Maybe<ILogger> logger)
 {
+    private static readonly HashSet<string> NonCompressibleExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "avif","avi","bmp","cab","cer","deb","divx","dvr-ms","flac","gif","gz","ico",
+        "jpeg","jpg","m4a","m4v","mkv","mov","mp3","mp4","mpeg","mpg","msi","msix",
+        "msixbundle","msm","msp","oga","ogg","ogv","opus","pdf","png","pfx","pri","svg",
+        "swf","tgz","tif","tiff","wav","webm","webp","wma","wmv","woff","woff2","xap",
+        "xbap","zip","zst","7z","rar","bz2","xz","lzma"
+    };
+
+    private static readonly IComparer<INamedByteSourceWithPath> FileOrderingComparer =
+        Comparer<INamedByteSourceWithPath>.Create(CompareFiles);
+
     public Result<IByteSource> Pack(IContainer container)
     {
         return Result.Success()
@@ -26,11 +40,14 @@ public class MsixPackager(Maybe<ILogger> logger)
     private async Task<Stream> GetStream(IList<INamedByteSourceWithPath> files)
     {
         var zipStream = new MemoryStream();
+        var orderedFiles = files
+            .OrderBy(file => file, FileOrderingComparer)
+            .ToList();
 
         await using (var zipper = new MsixBuilder(zipStream, logger))
         {
-            await WritePayload(files, zipper);
-            await WriteContentTypes(files, zipper);
+            await WritePayload(orderedFiles, zipper);
+            await WriteContentTypes(orderedFiles, zipper);
         }
 
         var finalStream = new MemoryStream();
@@ -59,7 +76,7 @@ public class MsixPackager(Maybe<ILogger> logger)
             MsixEntry entry;
             IList<DeflateBlock> blocks;
 
-            if (file.Name.EndsWith(".png"))
+            if (ShouldStore(file.Name))
             {
                 entry = new MsixEntry()
                 {
@@ -89,6 +106,8 @@ public class MsixPackager(Maybe<ILogger> logger)
                 blocks = await compressionBlocks.ToList();
             }
 
+            PopulateEntryMetadata(entry, blocks);
+
             await msix.PutNextEntry(entry);
 
             logger.Debug("Added entry for {File}", file.FullPath());
@@ -100,12 +119,150 @@ public class MsixPackager(Maybe<ILogger> logger)
         await AddBlockMap(msix, blockInfos);
     }
 
+    private static void PopulateEntryMetadata(MsixEntry entry, IList<DeflateBlock> blocks)
+    {
+        var crc32 = new System.IO.Hashing.Crc32();
+        long uncompressed = 0;
+        long compressed = 0;
+
+        foreach (var block in blocks)
+        {
+            if (block.OriginalData != null)
+            {
+                crc32.Append(block.OriginalData);
+                uncompressed += block.OriginalData.Length;
+            }
+
+            if (block.CompressedData != null)
+            {
+                compressed += block.CompressedData.Length;
+            }
+        }
+
+        entry.Crc32 = crc32.GetCurrentHashAsUInt32();
+        entry.UncompressedSize = uncompressed;
+        entry.CompressedSize = compressed;
+        entry.ModificationTime = DateTime.UtcNow.ToLocalTime();
+        entry.MetadataCalculated = true;
+    }
+
+    private static bool ShouldStore(string fileName)
+    {
+        var extension = System.IO.Path.GetExtension(fileName);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return false;
+        }
+
+        return NonCompressibleExtensions.Contains(extension.TrimStart('.'));
+    }
+
+    private static int FileDepth(INamedByteSourceWithPath file)
+    {
+        var fullPath = file.FullPath().ToString().Replace('\\', '/');
+        int depth = 0;
+        foreach (var ch in fullPath)
+        {
+            if (ch == '/')
+            {
+                depth++;
+            }
+        }
+
+        return depth;
+    }
+
+    private static string FileExtension(INamedByteSourceWithPath file)
+    {
+        var extension = System.IO.Path.GetExtension(file.Name);
+        return string.IsNullOrEmpty(extension) ? string.Empty : extension.TrimStart('.');
+    }
+
+    private static int CompareFiles(INamedByteSourceWithPath? left, INamedByteSourceWithPath? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return 0;
+        }
+
+        if (left is null)
+        {
+            return -1;
+        }
+
+        if (right is null)
+        {
+            return 1;
+        }
+
+        int depthComparison = FileDepth(right).CompareTo(FileDepth(left));
+        if (depthComparison != 0)
+        {
+            return depthComparison;
+        }
+
+        int extensionComparison = string.Compare(FileExtension(left), FileExtension(right), StringComparison.OrdinalIgnoreCase);
+        if (extensionComparison != 0)
+        {
+            return extensionComparison;
+        }
+
+        return CompareNatural(left.FullPath().ToString(), right.FullPath().ToString());
+    }
+
+    private static int CompareNatural(string left, string right)
+    {
+        int indexLeft = 0;
+        int indexRight = 0;
+
+        while (indexLeft < left.Length && indexRight < right.Length)
+        {
+            char charLeft = left[indexLeft];
+            char charRight = right[indexRight];
+
+            if (char.IsDigit(charLeft) && char.IsDigit(charRight))
+            {
+                long numberLeft = 0;
+                while (indexLeft < left.Length && char.IsDigit(left[indexLeft]))
+                {
+                    numberLeft = numberLeft * 10 + (left[indexLeft] - '0');
+                    indexLeft++;
+                }
+
+                long numberRight = 0;
+                while (indexRight < right.Length && char.IsDigit(right[indexRight]))
+                {
+                    numberRight = numberRight * 10 + (right[indexRight] - '0');
+                    indexRight++;
+                }
+
+                if (numberLeft != numberRight)
+                {
+                    return numberLeft.CompareTo(numberRight);
+                }
+            }
+            else
+            {
+                var comparison = char.ToUpperInvariant(charLeft).CompareTo(char.ToUpperInvariant(charRight));
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                indexLeft++;
+                indexRight++;
+            }
+        }
+
+        return (left.Length - indexLeft).CompareTo(right.Length - indexRight);
+    }
+
     private async Task AddBlockMap(MsixBuilder msix, List<FileBlockInfo> blockInfos)
     {
         logger.Debug("Adding Block Map");
         var blockMapModel = new BlockMapModel("SHA256", blockInfos.ToImmutableList());
         logger.Debug("Serializing block map");
-        var blockMapXml = await new BlockMapSerializer(logger).GenerateBlockMapXml(blockMapModel);
+        var blockMapXml = new BlockMapSerializer(logger).GenerateBlockMapXml(blockMapModel);
         logger.Debug("Block map serialized");
 
         logger.Debug("Adding Block Map entry to package");


### PR DESCRIPTION
## Summary
- make MSIX tests cross-platform by falling back to ZipArchive when makeappx is missing
- align content types, block map, zip metadata and entry ordering with makeappx output
- add regression tests comparing generated packages to the reference makeappx artifacts

## Testing
- dotnet test src/DotnetPackaging.Msix.Tests