### PR TITLE
feat(flatpak): add Flatpak CLI (layout, bundle, repo)

### DIFF
--- a/src/DotnetPackaging.Flatpak/DotnetPackaging.Flatpak.csproj
+++ b/src/DotnetPackaging.Flatpak/DotnetPackaging.Flatpak.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<Import Project="..\Common.props" />
+
+	<ItemGroup>
+		<ProjectReference Include="..\\DotnetPackaging\\DotnetPackaging.csproj" />
+		<ProjectReference Include="..\\DotnetPackaging.Deb\\DotnetPackaging.Deb.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/DotnetPackaging.Flatpak/FlatpakBuildPlan.cs
+++ b/src/DotnetPackaging.Flatpak/FlatpakBuildPlan.cs
@@ -1,0 +1,13 @@
+using Zafiro.DivineBytes;
+
+namespace DotnetPackaging.Flatpak;
+
+public record FlatpakBuildPlan(
+    string CommandName,
+    string ExecutableTargetPath,
+    string AppId,
+    PackageMetadata Metadata,
+    RootContainer Layout)
+{
+    public RootContainer ToRootContainer() => Layout;
+}

--- a/src/DotnetPackaging.Flatpak/FlatpakBundle.cs
+++ b/src/DotnetPackaging.Flatpak/FlatpakBundle.cs
@@ -1,0 +1,104 @@
+using CSharpFunctionalExtensions;
+using DotnetPackaging.Deb.Archives.Tar;
+using Zafiro.DataModel;
+using Zafiro.DivineBytes;
+using Zafiro.FileSystem.Unix;
+
+namespace DotnetPackaging.Flatpak;
+
+public static class FlatpakBundle
+{
+    // Legacy simple tar of layout
+    public static Result<IByteSource> Create(FlatpakBuildPlan plan)
+    {
+        var entries = ToTarEntries(plan);
+        var tar = new TarFile(entries.ToArray());
+        var data = tar.ToData();
+        return Result.Success(ByteSource.FromByteObservable(data.Bytes));
+    }
+
+    // Experimental: create an OSTree repo and bundle it (still unsigned)
+    public static Result<IByteSource> CreateOstree(FlatpakBuildPlan plan)
+    {
+        var repo = Ostree.OstreeRepoBuilder.Build(plan);
+        if (repo.IsFailure) return Result.Failure<IByteSource>(repo.Error);
+        // Tar the repo directory as a single file .flatpak
+        var tarEntries = new List<DotnetPackaging.Deb.Archives.Tar.TarEntry>();
+        foreach (var res in repo.Value.ResourcesWithPathsRecursive())
+        {
+            var p = $"./{((INamedWithPath)res).FullPath()}";
+            var props = DotnetPackaging.Deb.Archives.Tar.Misc.RegularFileProperties();
+            tarEntries.Add(new DotnetPackaging.Deb.Archives.Tar.FileTarEntry(p, Zafiro.DataModel.Data.FromByteArray(res.Array()), props));
+        }
+        var tar = new DotnetPackaging.Deb.Archives.Tar.TarFile(tarEntries.ToArray());
+        var data = tar.ToData();
+        return Result.Success(ByteSource.FromByteObservable(data.Bytes));
+    }
+
+    private static IEnumerable<TarEntry> ToTarEntries(FlatpakBuildPlan plan)
+    {
+        var files = new List<FileTarEntry>();
+        foreach (var res in plan.ToRootContainer().ResourcesWithPathsRecursive())
+        {
+            var path = NormalizeTarPath($"./{((INamedWithPath)res).FullPath()}");
+            var props = IsExecutable(plan, res) ? Misc.ExecutableFileProperties() : Misc.RegularFileProperties();
+            files.Add(new FileTarEntry(path, Data.FromByteArray(res.Array()), props));
+        }
+
+        var dirs = CreateDirectoryEntries(files.Select(f => (TarEntry)f));
+        return dirs.Concat(files);
+    }
+
+    private static bool IsExecutable(FlatpakBuildPlan plan, INamedByteSourceWithPath res)
+    {
+        var fullPath = ((INamedWithPath)res).FullPath().ToString().Replace("\\", "/");
+        return string.Equals(fullPath, $"{plan.ExecutableTargetPath}", StringComparison.Ordinal)
+               || fullPath.EndsWith($"/bin/{plan.CommandName}", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<TarEntry> CreateDirectoryEntries(IEnumerable<TarEntry> allFiles)
+    {
+        var directoryProperties = new TarDirectoryProperties
+        {
+            FileMode = "755".ToFileMode(),
+            GroupId = 1000,
+            OwnerId = 1000,
+            GroupName = "root",
+            OwnerUsername = "root",
+            LastModification = DateTimeOffset.Now
+        };
+
+        var directories = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var entry in allFiles)
+        {
+            var route = entry.Path.TrimStart('.');
+            route = route.TrimStart('/');
+            if (string.IsNullOrWhiteSpace(route)) continue;
+
+            var segments = route.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length == 0) continue;
+
+            var current = string.Empty;
+            for (var i = 0; i < segments.Length - 1; i++)
+            {
+                current = string.IsNullOrEmpty(current) ? $"./{segments[i]}" : $"{current}/{segments[i]}";
+                directories.Add(current);
+            }
+        }
+
+        return directories
+            .OrderBy(path => path.Count(c => c == '/'))
+            .ThenBy(path => path, StringComparer.Ordinal)
+            .Select(path => new DirectoryTarEntry(path, directoryProperties));
+    }
+
+    private static string NormalizeTarPath(string path)
+    {
+        var normalized = path.Replace("\\", "/");
+        while (normalized.Contains("//", StringComparison.Ordinal))
+        {
+            normalized = normalized.Replace("//", "/", StringComparison.Ordinal);
+        }
+        return normalized.StartsWith("./", StringComparison.Ordinal) ? normalized : $"./{normalized.TrimStart('/')}";
+    }
+}

--- a/src/DotnetPackaging.Flatpak/FlatpakFactory.cs
+++ b/src/DotnetPackaging.Flatpak/FlatpakFactory.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
+
+namespace DotnetPackaging.Flatpak;
+
+public class FlatpakFactory
+{
+    public async Task<Result<FlatpakBuildPlan>> BuildPlan(
+        IContainer applicationRoot,
+        PackageMetadata metadata,
+        FlatpakOptions? options = null)
+    {
+        var effectiveOptions = options ?? new FlatpakOptions();
+        
+        var executableResult = await BuildUtils.GetExecutable(applicationRoot, new FromDirectoryOptions());
+        if (executableResult.IsFailure)
+        {
+            return Result.Failure<FlatpakBuildPlan>(executableResult.Error);
+        }
+
+        var executable = executableResult.Value;
+        var appId = metadata.Id.GetValueOrDefault($"com.example.{metadata.Package}");
+        var commandName = effectiveOptions.CommandOverride.GetValueOrDefault(appId);
+        var executableTargetPath = $"bin/{executable.Name}";
+
+        // Compute metadata and app ID (Flatpak requires at least two dots)
+        // appId computed above
+
+        var planResult = await BuildPlanInternal(
+            applicationRoot, 
+            metadata, 
+            executable, 
+            effectiveOptions,
+            appId,
+            commandName,
+            executableTargetPath);
+
+        return planResult;
+    }
+
+    private async Task<Result<FlatpakBuildPlan>> BuildPlanInternal(
+        IContainer applicationRoot,
+        PackageMetadata metadata,
+        INamedByteSourceWithPath executable,
+        FlatpakOptions options,
+        string appId,
+        string commandName,
+        string executableTargetPath)
+    {
+        // Generate the metadata file
+        var metadataContent = GenerateMetadata(metadata, options, appId, commandName);
+
+        // Generate the .desktop file (Exec should be the appId)
+        var desktopFile = TextTemplates.DesktopFileContents(appId, metadata);
+
+        // Generate the appdata.xml file  
+        var appDataXml = TextTemplates.AppStream(metadata);
+
+        // Collect all application files under files/
+        var applicationFiles = new Dictionary<string, IByteSource>();
+        foreach (var file in applicationRoot.ResourcesWithPathsRecursive())
+        {
+            var targetPath = $"files/{executableTargetPath}";
+            if (file != executable)
+            {
+                // Put other files in the same bin directory
+                targetPath = $"files/bin/{file.Name}";
+            }
+            applicationFiles[targetPath] = file;
+        }
+        // Add wrapper with commandName -> actual executable
+        applicationFiles[$"files/bin/{commandName}"] = ByteSource.FromString(TextTemplates.RunScript($"/app/{executableTargetPath}"));
+
+        // Add desktop file under files/share so build-export can pick it
+        var desktopFileName = $"{appId}.desktop";
+        var desktopTargetPath = $"files/share/applications/{desktopFileName}";
+        applicationFiles[desktopTargetPath] = ByteSource.FromString(desktopFile);
+
+        // Add appdata.xml under files/share
+        var appDataFileName = $"{appId}.appdata.xml";  
+        var appDataTargetPath = $"files/share/metainfo/{appDataFileName}";
+        applicationFiles[appDataTargetPath] = ByteSource.FromString(appDataXml);
+
+        // Add icons under files/share
+        foreach (var iconFile in metadata.IconFiles)
+        {
+            var key = iconFile.Key;
+            var iconTargetPath = key.StartsWith("usr/share/")
+                ? key.Replace("usr/share/", "files/share/")
+                : $"files/share/{key}";
+            applicationFiles[iconTargetPath] = iconFile.Value;
+        }
+
+        // Add metadata file at root
+        applicationFiles["metadata"] = ByteSource.FromString(metadataContent);
+
+        var layoutResult = applicationFiles.ToRootContainer();
+        if (layoutResult.IsFailure)
+        {
+            return Result.Failure<FlatpakBuildPlan>(layoutResult.Error);
+        }
+
+        return Result.Success(new FlatpakBuildPlan(
+            commandName,
+            executableTargetPath, 
+            appId,
+            metadata,
+            layoutResult.Value));
+    }
+
+    private string GenerateMetadata(PackageMetadata metadata, FlatpakOptions options, string appId, string commandName)
+    {
+        var architecture = options.ArchitectureOverride.GetValueOrDefault(metadata.Architecture);
+        
+        var lines = new List<string>
+        {
+            "[Application]",
+            $"name={appId}",
+            $"runtime={options.Runtime}/{FlatpakArchitectureName(architecture)}/{options.RuntimeVersion}",
+            $"sdk={options.Sdk}/{FlatpakArchitectureName(architecture)}/{options.RuntimeVersion}",
+            $"branch={options.Branch}",
+            $"command={commandName}",
+            "",
+            "[Context]"
+        };
+
+        if (options.Shared.Any())
+        {
+            lines.Add($"shared={string.Join(";", options.Shared)};");
+        }
+
+        if (options.Sockets.Any())
+        {
+            lines.Add($"sockets={string.Join(";", options.Sockets)};");
+        }
+
+        if (options.Devices.Any()) 
+        {
+            lines.Add($"devices={string.Join(";", options.Devices)};");
+        }
+
+        if (options.Filesystems.Any())
+        {
+            lines.Add($"filesystems={string.Join(";", options.Filesystems)};");
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    private string FlatpakArchitectureName(Architecture architecture)
+    {
+        return architecture.PackagePrefix; // x86_64, aarch64, etc.
+    }
+}

--- a/src/DotnetPackaging.Flatpak/FlatpakOptions.cs
+++ b/src/DotnetPackaging.Flatpak/FlatpakOptions.cs
@@ -1,0 +1,24 @@
+using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
+using Zafiro.Mixins;
+
+namespace DotnetPackaging.Flatpak;
+
+public class FlatpakOptions
+{
+    // Flatpak base
+    public string Runtime { get; init; } = "org.freedesktop.Platform";
+    public string Sdk { get; init; } = "org.freedesktop.Sdk";
+    public string Branch { get; init; } = "stable";
+    public string RuntimeVersion { get; init; } = "23.08";
+
+    // Permissions (Context)
+    public IEnumerable<string> Shared { get; init; } = new[] { "network", "ipc" };
+    public IEnumerable<string> Sockets { get; init; } = new[] { "wayland", "x11", "pulseaudio" };
+    public IEnumerable<string> Devices { get; init; } = new[] { "dri" };
+    public IEnumerable<string> Filesystems { get; init; } = new[] { "home" };
+
+    // Overrides
+    public Maybe<Architecture> ArchitectureOverride { get; init; } = Maybe<Architecture>.None;
+    public Maybe<string> CommandOverride { get; init; } = Maybe<string>.None;
+}

--- a/src/DotnetPackaging.Flatpak/GVariant.cs
+++ b/src/DotnetPackaging.Flatpak/GVariant.cs
@@ -1,0 +1,31 @@
+namespace DotnetPackaging.Flatpak.Ostree;
+
+// Minimal GVariant builder (scaffold). Not spec-complete; replace incrementally.
+internal sealed class GVariant
+{
+    private readonly List<byte> buffer = new();
+
+    public static GVariant Create() => new();
+
+    public GVariant String(string s)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(s);
+        buffer.AddRange(bytes);
+        buffer.Add(0); // nul-terminated (scaffold)
+        return this;
+    }
+
+    public GVariant UInt64(ulong value)
+    {
+        buffer.AddRange(BitConverter.GetBytes(value));
+        return this;
+    }
+
+    public GVariant Bytes(byte[] data)
+    {
+        buffer.AddRange(data);
+        return this;
+    }
+
+    public byte[] ToArray() => buffer.ToArray();
+}

--- a/src/DotnetPackaging.Flatpak/OstreeEncoders.cs
+++ b/src/DotnetPackaging.Flatpak/OstreeEncoders.cs
@@ -1,0 +1,28 @@
+using System.Text;
+
+namespace DotnetPackaging.Flatpak.Ostree;
+
+internal static class OstreeEncoders
+{
+    // Placeholder encoders. Will be replaced by proper GVariant serialization.
+    public static byte[] EncodeTree(IReadOnlyDictionary<string, string> entries)
+    {
+        // Scaffold using minimal GVariant-like layout: [name0\0sha0\0][name1\0sha1\0]...
+        var gv = GVariant.Create();
+        foreach (var kv in entries.OrderBy(k => k.Key, StringComparer.Ordinal))
+        {
+            gv.String(kv.Key).String(kv.Value);
+        }
+        return gv.ToArray();
+    }
+
+    public static byte[] EncodeCommit(string treeChecksum, string subject, DateTimeOffset timestamp)
+    {
+        // Scaffold using minimal GVariant-like layout
+        var gv = GVariant.Create()
+            .String(treeChecksum)
+            .String(subject)
+            .UInt64((ulong)timestamp.ToUnixTimeSeconds());
+        return gv.ToArray();
+    }
+}

--- a/src/DotnetPackaging.Flatpak/OstreeRepoBuilder.cs
+++ b/src/DotnetPackaging.Flatpak/OstreeRepoBuilder.cs
@@ -1,0 +1,90 @@
+using System.Security.Cryptography;
+using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
+
+namespace DotnetPackaging.Flatpak.Ostree;
+
+// Simplified object kinds with pluggable encoders (GVariant to be added)
+internal abstract record OstreeObject(string Type)
+{
+    public abstract byte[] Serialize();
+}
+
+internal sealed record Blob(byte[] Content) : OstreeObject("blob")
+{
+    public override byte[] Serialize() => Content;
+}
+
+internal sealed record Tree(Dictionary<string, string> Entries) : OstreeObject("tree")
+{
+    public override byte[] Serialize()
+    {
+        // TODO: Replace with real GVariant tree encoding
+        return OstreeEncoders.EncodeTree(Entries);
+    }
+}
+
+internal sealed record Commit(string TreeChecksum, string Subject, DateTimeOffset Timestamp) : OstreeObject("commit")
+{
+    public override byte[] Serialize()
+    {
+        // TODO: Replace with real GVariant commit encoding
+        return OstreeEncoders.EncodeCommit(TreeChecksum, Subject, Timestamp);
+    }
+}
+
+public static class OstreeRepoBuilder
+{
+    public static Result<RootContainer> Build(FlatpakBuildPlan plan)
+    {
+        // 1) Create blob objects from layout files under commit root (metadata, files/, export/)
+        var blobs = new Dictionary<string, (string checksum, IByteSource source)>(StringComparer.Ordinal);
+        foreach (var res in plan.ToRootContainer().ResourcesWithPathsRecursive())
+        {
+            var bytes = res.Array();
+            var checksum = Sha256(bytes);
+            blobs[((INamedWithPath)res).FullPath().ToString()] = (checksum, ByteSource.FromBytes(bytes));
+        }
+
+        // 2) Tree maps file paths to blob checksums (flat list)
+        var treeEntries = blobs.ToDictionary(k => k.Key, v => v.Value.checksum, StringComparer.Ordinal);
+        var tree = new Tree(treeEntries);
+        var treeBytes = tree.Serialize();
+        var treeChecksum = Sha256(treeBytes);
+
+        // 3) Commit referencing tree
+        var commit = new Commit(treeChecksum, plan.Metadata.Name, DateTimeOffset.Now);
+        var commitBytes = commit.Serialize();
+        var commitChecksum = Sha256(commitBytes);
+
+        // 4) Build repo layout
+        var repoFiles = new Dictionary<string, IByteSource>(StringComparer.Ordinal)
+        {
+            ["config"] = ByteSource.FromString("[core]\nrepo_version=1\nmode=bare-user\n"),
+            [$"refs/heads/app/{plan.AppId}/{plan.Metadata.Architecture.PackagePrefix}/stable"] = ByteSource.FromString(commitChecksum),
+            ["summary"] = ByteSource.FromBytes(Array.Empty<byte>())
+        };
+
+        // objects for blobs
+        foreach (var b in blobs)
+        {
+            var content = new Blob(b.Value.source.Array()).Serialize();
+            var chk = Sha256(content);
+            var path = $"objects/{chk.Substring(0,2)}/{chk.Substring(2)}";
+            repoFiles[path] = ByteSource.FromBytes(content);
+        }
+
+        // tree object
+        repoFiles[$"objects/{treeChecksum[..2]}/{treeChecksum[2..]}"] = ByteSource.FromBytes(treeBytes);
+        // commit object
+        repoFiles[$"objects/{commitChecksum[..2]}/{commitChecksum[2..]}"] = ByteSource.FromBytes(commitBytes);
+
+        return repoFiles.ToRootContainer();
+    }
+
+    private static string Sha256(byte[] bytes)
+    {
+        using var sha = SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(bytes)).ToLowerInvariant();
+    }
+}

--- a/src/DotnetPackaging.Tool/DotnetPackaging.Tool.csproj
+++ b/src/DotnetPackaging.Tool/DotnetPackaging.Tool.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DotnetPackaging.AppImage\DotnetPackaging.AppImage.csproj" />
     <ProjectReference Include="..\DotnetPackaging.Deb\DotnetPackaging.Deb.csproj" />
+    <ProjectReference Include="..\DotnetPackaging.Flatpak\DotnetPackaging.Flatpak.csproj" />
     <ProjectReference Include="..\DotnetPackaging\DotnetPackaging.csproj" />
   </ItemGroup>
   <!-- Toggle Zafiro: local projects in Debug, NuGet packages in Release (central versions in Directory.Packages.props) -->


### PR DESCRIPTION
This PR introduces Flatpak packaging support in the CLI.\n\nHighlights:\n- New `flatpak` command with subcommands:\n  - `layout`: build Flatpak layout (metadata + files/) without external tools.\n  - `bundle`: create a .flatpak bundle. Supports internal bundler (experimental) or system `flatpak` via `--system`.\n  - `repo`: build an OSTree repository directory for debugging/validation.\n- Rich options via a dedicated binder: runtime/sdk/branch/runtime-version, permissions (shared/sockets/devices/filesystems), arch override, and command override.\n- Ensures wrapper and target executable have executable bits before `build-export`/`build-bundle`.\n- Help text tweaks.\n\nManual validation:\n- Published a sample Avalonia app, generated a bundle with `--system`, installed it, and verified it launches under Flatpak.\n\nNotes:\n- The internal bundler (OSTree scaffold) remains experimental and unsigned; system mode is recommended for distribution.\n- freedesktop 23.08 is EOL; tested install works but 24.08 is recommended moving forward.