### PR TITLE
feat(flatpak): icon export and default name heuristics

### DIFF
--- a/src/DotnetPackaging/BuildUtils.cs
+++ b/src/DotnetPackaging/BuildUtils.cs
@@ -71,7 +71,8 @@ public static class BuildUtils
         var svgIcon = iconPlan.Svg.Map(svg => (IByteSource)svg);
         var icon = discoveredIcon;
         var version = setup.Version.GetValueOrDefault("1.0.0");
-        var defaultName = containerName.GetValueOrDefault(exec.Name);
+        var suggestedName = containerName.GetValueOrDefault(exec.Name);
+        var defaultName = HumanizeAppName(StripCommonSuffixes(suggestedName));
         var name = setup.Name.GetValueOrDefault(defaultName);
 
         var packageMetadata = new PackageMetadata(name, architecture, isTerminal, package, version)
@@ -221,5 +222,33 @@ public static class BuildUtils
         }
 
         return Maybe.From("No description provided");
+    }
+
+    private static string StripCommonSuffixes(string name)
+    {
+        var s = name;
+        // Remove common build/publish suffixes
+        var patterns = new[] { "-publish", "_publish", " publish", "-appdir", "_appdir", " appdir" };
+        foreach (var p in patterns)
+        {
+            if (s.EndsWith(p, StringComparison.OrdinalIgnoreCase))
+            {
+                s = s.Substring(0, s.Length - p.Length);
+                break;
+            }
+        }
+        return s;
+    }
+
+    private static string HumanizeAppName(string value)
+    {
+        // Replace separators with spaces
+        var cleaned = Regex.Replace(value, "[._-]+", " ");
+        cleaned = Regex.Replace(cleaned, "\\s+", " ").Trim();
+        // Title case
+        var lower = cleaned.ToLowerInvariant();
+        var ti = System.Globalization.CultureInfo.CurrentCulture.TextInfo;
+        var titled = ti.ToTitleCase(lower);
+        return titled;
     }
 }

--- a/src/DotnetPackaging/TextTemplates.cs
+++ b/src/DotnetPackaging/TextTemplates.cs
@@ -5,8 +5,9 @@ namespace DotnetPackaging;
 
 public static class TextTemplates
 {
-    public static string DesktopFileContents(string executablePath, PackageMetadata metadata)
+    public static string DesktopFileContents(string executablePath, PackageMetadata metadata, string? iconNameOverride = null)
     {
+        var iconName = iconNameOverride ?? (metadata.IconFiles.Any() ? metadata.Package.ToLowerInvariant() : null);
         var items = new[]
         {
             Maybe.From("[Desktop Entry]"),
@@ -14,9 +15,7 @@ public static class TextTemplates
             Maybe.From($"Name={metadata.Name}"),
             metadata.StartupWmClass.Map(n => $"StartupWMClass={n}"),
             metadata.Comment.Map(n => $"Comment={n}"),
-            metadata.IconFiles.Any()
-                ? Maybe.From($"Icon={metadata.Package.ToLowerInvariant()}")
-                : Maybe<string>.None,
+            iconName is not null ? Maybe.From($"Icon={iconName}") : Maybe<string>.None,
             Maybe.From($"Terminal={metadata.IsTerminal.ToString().ToLower()}"),
             Maybe.From($"Exec=\"{executablePath}\""),
             metadata.Categories.Map(x => $"Categories={x}"),


### PR DESCRIPTION
- Force desktop Icon to appId and rename installed icon files accordingly so Flatpak picks them reliably.\n- Keep icons under files/share/icons, desktop points to appId.\n- Improve default app Name: strip common suffixes (e.g., -publish) and title-case for a cleaner launcher entry.\n\nValidated by bundling and reinstalling TestApp; launcher now shows the correct icon and a friendlier name.