### PR TITLE
flatpak: preserve Flatpak layout and executable bit

### DIFF
--- a/src/DotnetPackaging.Flatpak/FlatpakBundle.cs
+++ b/src/DotnetPackaging.Flatpak/FlatpakBundle.cs
@@ -52,7 +52,7 @@ public static class FlatpakBundle
     private static bool IsExecutable(FlatpakBuildPlan plan, INamedByteSourceWithPath res)
     {
         var fullPath = ((INamedWithPath)res).FullPath().ToString().Replace("\\", "/");
-        return string.Equals(fullPath, $"{plan.ExecutableTargetPath}", StringComparison.Ordinal)
+        return string.Equals(fullPath, $"files/{plan.ExecutableTargetPath}", StringComparison.Ordinal)
                || fullPath.EndsWith($"/bin/{plan.CommandName}", StringComparison.Ordinal);
     }
 

--- a/src/DotnetPackaging.Flatpak/FlatpakFactory.cs
+++ b/src/DotnetPackaging.Flatpak/FlatpakFactory.cs
@@ -59,15 +59,16 @@ public class FlatpakFactory
 
         // Collect all application files under files/
         var applicationFiles = new Dictionary<string, IByteSource>();
-        foreach (var file in applicationRoot.ResourcesWithPathsRecursive())
+        foreach (var res in applicationRoot.ResourcesWithPathsRecursive())
         {
             var targetPath = $"files/{executableTargetPath}";
-            if (file != executable)
+            if (res != executable)
             {
-                // Put other files in the same bin directory
-                targetPath = $"files/bin/{file.Name}";
+                // Preserve original relative layout under files/
+                var full = ((INamedWithPath)res).FullPath().ToString().Replace("\\", "/");
+                targetPath = $"files/{full}";
             }
-            applicationFiles[targetPath] = file;
+            applicationFiles[targetPath] = res;
         }
         // Add wrapper with commandName -> actual executable
         applicationFiles[$"files/bin/{commandName}"] = ByteSource.FromString(TextTemplates.RunScript($"/app/{executableTargetPath}"));


### PR DESCRIPTION
This PR fixes two issues identified during review of Flatpak CLI work:\n\n- Preserve original directory hierarchy under files/ instead of flattening into files/bin.\n- Correctly detect and mark executable files in tar bundle: files/{ExecutableTargetPath} and files/bin/{CommandName}.\n\nBuild and tests pass locally.