### PR TITLE
flatpak: follow-ups — keep original layout, .metainfo.xml, root ownership

### DIFF
--- a/src/DotnetPackaging.Flatpak/FlatpakBundle.cs
+++ b/src/DotnetPackaging.Flatpak/FlatpakBundle.cs
@@ -41,7 +41,8 @@ public static class FlatpakBundle
         foreach (var res in plan.ToRootContainer().ResourcesWithPathsRecursive())
         {
             var path = NormalizeTarPath($"./{((INamedWithPath)res).FullPath()}");
-            var props = IsExecutable(plan, res) ? Misc.ExecutableFileProperties() : Misc.RegularFileProperties();
+            var baseProps = IsExecutable(plan, res) ? Misc.ExecutableFileProperties() : Misc.RegularFileProperties();
+            var props = baseProps with { OwnerId = 0, GroupId = 0, OwnerUsername = "root", GroupName = "root" };
             files.Add(new FileTarEntry(path, Data.FromByteArray(res.Array()), props));
         }
 
@@ -61,8 +62,8 @@ public static class FlatpakBundle
         var directoryProperties = new TarDirectoryProperties
         {
             FileMode = "755".ToFileMode(),
-            GroupId = 1000,
-            OwnerId = 1000,
+            GroupId = 0,
+            OwnerId = 0,
             GroupName = "root",
             OwnerUsername = "root",
             LastModification = DateTimeOffset.Now


### PR DESCRIPTION
Addressing feedback on PR #70:\n\n- Keep executable at its original path; wrapper in files/bin/<command> runs /app/<original-path>.\n- Use <appId>.metainfo.xml under files/share/metainfo (instead of .appdata.xml).\n- Ensure root:root (0:0) ownership for files and directories in internal tar bundle.\n\nBuild and tests pass locally.