### PR TITLE
RPM: portable self-contained packages (exclude auto-deps, avoid owning system dirs) + docs update

### DIFF
--- a/src/DotnetPackaging.Rpm/Builder/RpmPackager.cs
+++ b/src/DotnetPackaging.Rpm/Builder/RpmPackager.cs
@@ -127,6 +127,11 @@ internal static class RpmPackager
         builder.AppendLine($"Vendor: {vendor}");
         builder.AppendLine($"BuildArch: {buildArch}");
         builder.AppendLine();
+        // Exclude bundled .NET runtime files under /opt/<package> from auto dependency/provides
+        // This prevents rpmbuild from adding hard Requires like liblttng-ust.so.0, making the RPM more portable across RPM-based distros
+        builder.AppendLine($"%global __requires_exclude_from ^/opt/{metadata.Package}/.*$");
+        builder.AppendLine($"%global __provides_exclude_from ^/opt/{metadata.Package}/.*$");
+        builder.AppendLine();
         builder.AppendLine("%description");
         builder.AppendLine(description);
         builder.AppendLine();


### PR DESCRIPTION
Summary
- Make RPMs portable across Fedora/RHEL/openSUSE by preventing rpmbuild from auto-injecting native Requires/Provides from bundled .NET runtime under /opt/<package>.
- Avoid owning system directories (/, /usr, /usr/bin, etc.) in %files. Only own /opt/<package> tree and explicitly installed files (.desktop in /usr/share/applications and wrapper in /usr/bin).
- Update WARP.md: document RPM support, portability strategy, prerequisites, CLI examples.

Details
- Spec: add %global __requires_exclude_from and %global __provides_exclude_from for ^/opt/<package>/.*$.
- Layout: restrict generated %dir entries to directories under /opt/<package>.
- Result: self-contained .NET apps no longer pull hard dependencies like liblttng-ust.so.0 on distros where SONAME differs; installation succeeds without conflicts with filesystem package.

Testing
- Built and installed a sample Avalonia app RPM; confirmed no Requires on liblttng-ust.so.0 and successful installation.

Docs
- WARP.md updated: CLI now lists rpm verb; examples added; RPM prerequisites and portability notes included.