### PR TITLE
Add project publisher + ; share containerization; keep CLI thin

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="System.Security.Permissions" Version="9.0.5" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Extensions" Version="2.2.5" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="22.0.14" />
+    <PackageVersion Include="System.IO.Abstractions" Version="22.0.14" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0">

--- a/src/DotnetPackaging.Rpm/Builder/RpmBuilder.cs
+++ b/src/DotnetPackaging.Rpm/Builder/RpmBuilder.cs
@@ -25,12 +25,6 @@ public class RpmBuilder
 
     private static Result<RootContainer> BuildContainer(IDirectory root)
     {
-        var files = root.RootedFiles()
-            .ToDictionary(
-                file => file.Path == ZafiroPath.Empty ? file.Name : file.Path.Combine(file.Name).ToString(),
-                file => (IByteSource)ByteSource.FromByteObservable(file.Value.Bytes),
-                StringComparer.Ordinal);
-
-        return files.ToRootContainer();
+        return ContainerUtils.BuildContainer(root);
     }
 }

--- a/src/DotnetPackaging/ContainerUtils.cs
+++ b/src/DotnetPackaging/ContainerUtils.cs
@@ -1,0 +1,20 @@
+using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
+using Zafiro.FileSystem.Core;
+using Zafiro.FileSystem.Readonly;
+
+namespace DotnetPackaging;
+
+public static class ContainerUtils
+{
+    public static Result<RootContainer> BuildContainer(IDirectory root)
+    {
+        var files = root.RootedFiles()
+            .ToDictionary(
+                file => file.Path == ZafiroPath.Empty ? file.Name : file.Path.Combine(file.Name).ToString(),
+                file => (IByteSource)ByteSource.FromByteObservable(file.Value.Bytes),
+                StringComparer.Ordinal);
+
+        return files.ToRootContainer();
+    }
+}

--- a/src/DotnetPackaging/DotnetPackaging.csproj
+++ b/src/DotnetPackaging/DotnetPackaging.csproj
@@ -10,15 +10,22 @@
         <PackageReference Include="NuGet.Versioning" />
     </ItemGroup>
     
-    <ItemGroup Condition="'$(UseLocalZafiroReferences)' == 'true'">
+  <ItemGroup Condition="'$(UseLocalZafiroReferences)' == 'true'">
       <ProjectReference Include="..\..\libs\Zafiro\src\Zafiro.DivineBytes\Zafiro.DivineBytes.csproj" />
       <ProjectReference Include="..\..\libs\Zafiro\src\Zafiro.FileSystem\Zafiro.FileSystem.csproj" />
+      <ProjectReference Include="..\..\libs\Zafiro\src\Zafiro.FileSystem.Local\Zafiro.FileSystem.Local.csproj" />
       <ProjectReference Include="..\..\libs\Zafiro\src\Zafiro\Zafiro.csproj" />
     </ItemGroup>
   <ItemGroup Condition="'$(UseLocalZafiroReferences)' == 'false'">
       <PackageReference Include="Zafiro.DivineBytes" />
       <PackageReference Include="Zafiro.FileSystem" />
+      <PackageReference Include="Zafiro.FileSystem.Local" />
       <PackageReference Include="Zafiro" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
+    <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/DotnetPackaging/Publish/DotnetPublisher.cs
+++ b/src/DotnetPackaging/Publish/DotnetPublisher.cs
@@ -1,0 +1,103 @@
+using System.Diagnostics;
+using CSharpFunctionalExtensions;
+using System.IO.Abstractions;
+using Zafiro.DivineBytes;
+using Zafiro.FileSystem.Core;
+using Zafiro.FileSystem.Local;
+using Zafiro.FileSystem.Readonly;
+
+namespace DotnetPackaging.Publish;
+
+public sealed class DotnetPublisher : IPublisher
+{
+    public async Task<Result<PublishResult>> Publish(ProjectPublishRequest request)
+    {
+        try
+        {
+            var outputDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dp-publish-{Guid.NewGuid():N}");
+            System.IO.Directory.CreateDirectory(outputDir);
+
+            var args = BuildArgs(request, outputDir);
+            var run = await Run("dotnet", args);
+            if (run.IsFailure)
+            {
+                return Result.Failure<PublishResult>(run.Error);
+            }
+
+            // Wrap published directory as Zafiro read-only directory, then convert to a RootContainer
+            var fs = new System.IO.Abstractions.FileSystem();
+            var localDir = new Zafiro.FileSystem.Local.Directory(fs.DirectoryInfo.New(outputDir));
+            var readOnly = await localDir.ToDirectory();
+            if (readOnly.IsFailure)
+            {
+                return Result.Failure<PublishResult>($"Unable to materialize directory: {readOnly.Error}");
+            }
+
+            var containerResult = ContainerUtils.BuildContainer(readOnly.Value);
+            if (containerResult.IsFailure)
+            {
+                return Result.Failure<PublishResult>(containerResult.Error);
+            }
+
+            var name = DeriveName(request.ProjectPath);
+            return Result.Success(new PublishResult(containerResult.Value, name, outputDir));
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<PublishResult>(ex.Message);
+        }
+    }
+
+    private static Maybe<string> DeriveName(string projectPath)
+    {
+        try
+        {
+            var fileName = System.IO.Path.GetFileNameWithoutExtension(projectPath);
+            return string.IsNullOrWhiteSpace(fileName) ? Maybe<string>.None : Maybe<string>.From(fileName);
+        }
+        catch
+        {
+            return Maybe<string>.None;
+        }
+    }
+
+    private static string BuildArgs(ProjectPublishRequest r, string outputDir)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append($"publish \"{r.ProjectPath}\" ");
+        sb.Append($"-c {r.Configuration} ");
+        if (r.Rid.HasValue) sb.Append($"-r {r.Rid.Value} ");
+        sb.Append(r.SelfContained ? "--self-contained true " : "--self-contained false ");
+        if (r.SingleFile) sb.Append("/p:PublishSingleFile=true ");
+        if (r.Trimmed) sb.Append("/p:PublishTrimmed=true ");
+        sb.Append($"-o \"{outputDir}\"");
+        return sb.ToString();
+    }
+
+    private static async Task<Result> Run(string fileName, string arguments)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(fileName, arguments)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            using var p = Process.Start(psi)!;
+            await p.WaitForExitAsync();
+            if (p.ExitCode != 0)
+            {
+                var err = await p.StandardError.ReadToEndAsync();
+                var outp = await p.StandardOutput.ReadToEndAsync();
+                return Result.Failure($"{fileName} {arguments}\nExitCode: {p.ExitCode}\n{outp}\n{err}");
+            }
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure(ex.Message);
+        }
+    }
+}

--- a/src/DotnetPackaging/Publish/IPublisher.cs
+++ b/src/DotnetPackaging/Publish/IPublisher.cs
@@ -1,0 +1,8 @@
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Publish;
+
+public interface IPublisher
+{
+    Task<Result<PublishResult>> Publish(ProjectPublishRequest request);
+}

--- a/src/DotnetPackaging/Publish/ProjectPublishRequest.cs
+++ b/src/DotnetPackaging/Publish/ProjectPublishRequest.cs
@@ -1,0 +1,19 @@
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Publish;
+
+public sealed class ProjectPublishRequest
+{
+    public ProjectPublishRequest(string projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath)) throw new ArgumentException("Value cannot be null or empty", nameof(projectPath));
+        ProjectPath = projectPath;
+    }
+
+    public string ProjectPath { get; }
+    public Maybe<string> Rid { get; init; } = Maybe<string>.None;
+    public bool SelfContained { get; init; } = true;
+    public string Configuration { get; init; } = "Release";
+    public bool SingleFile { get; init; }
+    public bool Trimmed { get; init; }
+}

--- a/src/DotnetPackaging/Publish/PublishResult.cs
+++ b/src/DotnetPackaging/Publish/PublishResult.cs
@@ -1,0 +1,5 @@
+using Zafiro.DivineBytes;
+
+namespace DotnetPackaging.Publish;
+
+public sealed record PublishResult(RootContainer Container, Maybe<string> Name, string OutputDirectory);


### PR DESCRIPTION
Summary
- Library: introduce IPublisher and DotnetPublisher to publish a .NET project to a temp directory and expose it as a RootContainer (no File/Stream usage by consumers).
- Share containerization: new ContainerUtils.BuildContainer(IDirectory) used by RPM builder and publisher to avoid duplication.
- CLI: add  subcommand that publishes a project (RID/self-contained/etc.) and reuses existing packaging pipeline.

Details
- Uses System.IO.Abstractions to wrap the published folder via Zafiro.FileSystem.Local and convert to read-only + RootContainer.
- No changes to format builders; CLI remains a thin orchestrator.

Testing
- Built solution and validated new subcommand compiles; existing RPM flow unchanged.

Next steps
- Consider analogous  and  for parity.
