### PR TITLE
CLI: flatpak from-project + experimental msix pack/from-project

### DIFF
--- a/src/DotnetPackaging.Tool/DotnetPackaging.Tool.csproj
+++ b/src/DotnetPackaging.Tool/DotnetPackaging.Tool.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\DotnetPackaging.Flatpak\DotnetPackaging.Flatpak.csproj" />
     <ProjectReference Include="..\DotnetPackaging.Dmg\DotnetPackaging.Dmg.csproj" />
     <ProjectReference Include="..\DotnetPackaging.Rpm\DotnetPackaging.Rpm.csproj" />
+    <ProjectReference Include="..\DotnetPackaging.Msix\DotnetPackaging.Msix.csproj" />
     <ProjectReference Include="..\DotnetPackaging\DotnetPackaging.csproj" />
   </ItemGroup>
   <!-- Toggle Zafiro: local projects in Debug, NuGet packages in Release (central versions in Directory.Packages.props) -->


### PR DESCRIPTION
Summary
- Flatpak: add from-project (bundles to .flatpak; supports --system; reuses metadata + Flatpak options binders).
- MSIX (experimental): add msix pack (from directory) and msix from-project; both reuse library Msix.FromDirectory.
- Tool now references DotnetPackaging.Msix project.

Notes
- from-project defaults to framework-dependent unless specified otherwise in rpm/deb/appimage subcommands (flatpak from-project uses defaults).
- MSIX assumes directory contains a valid AppxManifest.xml or pre-baked assets; generation from metadata can be added later.
