### PR TITLE
Publisher RID inference + default self-contained for from-project

### DIFF
--- a/src/DotnetPackaging.Tool/Program.cs
+++ b/src/DotnetPackaging.Tool/Program.cs
@@ -871,7 +871,7 @@ static class Program
     {
         var project = new Option<FileInfo>("--project", "Path to the .csproj file") { IsRequired = true };
         var rid = new Option<string?>("--rid", "Runtime identifier (e.g. linux-x64, linux-arm64)");
-        var selfContained = new Option<bool>("--self-contained", () => false, "Publish self-contained");
+        var selfContained = new Option<bool>("--self-contained", () => true, "Publish self-contained");
         var configuration = new Option<string>("--configuration", () => "Release", "Build configuration");
         var singleFile = new Option<bool>("--single-file", "Publish single-file");
         var trimmed = new Option<bool>("--trimmed", "Enable trimming");
@@ -922,13 +922,6 @@ static class Program
 
         fromProject.SetHandler(async (FileInfo prj, string? ridVal, bool sc, string cfg, bool sf, bool tr, FileInfo outFile, Options opt) =>
         {
-            if (sc && string.IsNullOrWhiteSpace(ridVal))
-            {
-                Console.Error.WriteLine("When --self-contained is true, you must specify --rid (e.g., linux-x64). Defaulting self-contained to false otherwise.");
-                Environment.ExitCode = 2;
-                return;
-            }
-
             var publisher = new DotnetPackaging.Publish.DotnetPublisher();
             var req = new DotnetPackaging.Publish.ProjectPublishRequest(prj.FullName)
             {
@@ -973,7 +966,7 @@ static class Program
     {
         var project = new Option<FileInfo>("--project", "Path to the .csproj file") { IsRequired = true };
         var rid = new Option<string?>("--rid", "Runtime identifier (e.g. linux-x64, linux-arm64)");
-        var selfContained = new Option<bool>("--self-contained", () => false, "Publish self-contained");
+        var selfContained = new Option<bool>("--self-contained", () => true, "Publish self-contained");
         var configuration = new Option<string>("--configuration", () => "Release", "Build configuration");
         var singleFile = new Option<bool>("--single-file", "Publish single-file");
         var trimmed = new Option<bool>("--trimmed", "Enable trimming");
@@ -1023,13 +1016,6 @@ static class Program
 
         fromProject.SetHandler(async (FileInfo prj, string? ridVal, bool sc, string cfg, bool sf, bool tr, FileInfo outFile, Options opt) =>
         {
-            if (sc && string.IsNullOrWhiteSpace(ridVal))
-            {
-                Console.Error.WriteLine("When --self-contained is true, you must specify --rid (e.g., linux-x64). Defaulting self-contained to false otherwise.");
-                Environment.ExitCode = 2;
-                return;
-            }
-
             var publisher = new DotnetPackaging.Publish.DotnetPublisher();
             var req = new DotnetPackaging.Publish.ProjectPublishRequest(prj.FullName)
             {
@@ -1105,13 +1091,6 @@ static class Program
         fromProject.AddOption(outMsix);
         fromProject.SetHandler(async (FileInfo prj, string? ridVal, bool sc, string cfg, bool sf, bool tr, FileInfo outFile) =>
         {
-            if (sc && string.IsNullOrWhiteSpace(ridVal))
-            {
-                Console.Error.WriteLine("When --self-contained is true, you must specify --rid (e.g., win-x64). Defaulting self-contained to false otherwise.");
-                Environment.ExitCode = 2;
-                return;
-            }
-
             var publisher = new DotnetPackaging.Publish.DotnetPublisher();
             var req = new DotnetPackaging.Publish.ProjectPublishRequest(prj.FullName)
             {
@@ -1140,7 +1119,7 @@ static class Program
     {
         var project = new Option<FileInfo>("--project", "Path to the .csproj file") { IsRequired = true };
         var rid = new Option<string?>("--rid", "Runtime identifier (e.g. linux-x64, linux-arm64)");
-        var selfContained = new Option<bool>("--self-contained", () => false, "Publish self-contained");
+        var selfContained = new Option<bool>("--self-contained", () => true, "Publish self-contained");
         var configuration = new Option<string>("--configuration", () => "Release", "Build configuration");
         var singleFile = new Option<bool>("--single-file", "Publish single-file");
         var trimmed = new Option<bool>("--trimmed", "Enable trimming");


### PR DESCRIPTION
Summary
- Publisher: infer host RID when --self-contained=true and --rid is not provided (linux-x64, win-x64, osx-*, arm64 variants).
- CLI: from-project defaults to --self-contained=true in rpm/deb/appimage/msix; relies on publisher RID inference, keeping UX simple.

Notes
- Flatpak from-project continues to publish framework-dependent by default; can be extended similarly if needed.
- Behavior: cross-RID still requires explicit --rid.
