### PR TITLE
CLI: appimage from-project relies on RID inference (remove --rid gate)

### DIFF
--- a/src/DotnetPackaging.Tool/Program.cs
+++ b/src/DotnetPackaging.Tool/Program.cs
@@ -1170,13 +1170,6 @@ static class Program
 
         fromProject.SetHandler(async (FileInfo prj, string? ridVal, bool sc, string cfg, bool sf, bool tr, FileInfo outFile, Options opt) =>
         {
-            if (sc && string.IsNullOrWhiteSpace(ridVal))
-            {
-                Console.Error.WriteLine("When --self-contained is true, you must specify --rid (e.g., linux-x64). Defaulting self-contained to false otherwise.");
-                Environment.ExitCode = 2;
-                return;
-            }
-
             var publisher = new DotnetPackaging.Publish.DotnetPublisher();
             var req = new DotnetPackaging.Publish.ProjectPublishRequest(prj.FullName)
             {


### PR DESCRIPTION
Fix
- Remove manual RID check in appimage from-project; keep parity with rpm/deb/msix and use publisher host RID inference when --rid is omitted.

Context: Codex review on PR #82.