### PR TITLE
Add welcome step to installer wizard

### DIFF
--- a/src/DotnetPackaging.InstallerStub/MainView.axaml
+++ b/src/DotnetPackaging.InstallerStub/MainView.axaml
@@ -14,6 +14,13 @@
     </Interaction.Behaviors>
     
     <UserControl.DataTemplates>
+        <DataTemplate DataType="{x:Type installerStub:WelcomePageVM}">
+            <StackPanel Spacing="12">
+                <TextBlock Text="{Binding Heading}" FontSize="20" FontWeight="Bold"/>
+                <TextBlock Text="{Binding Description}" TextWrapping="Wrap"/>
+                <TextBlock Text="{Binding AdditionalInfo}" TextWrapping="Wrap"/>
+            </StackPanel>
+        </DataTemplate>
         <DataTemplate DataType="{x:Type installerStub:OptionsPageVM}">
             <StackPanel Spacing="8">
                 <TextBlock Text="Choose destination folder" FontWeight="Bold"/>

--- a/src/DotnetPackaging.InstallerStub/WelcomePageVM.cs
+++ b/src/DotnetPackaging.InstallerStub/WelcomePageVM.cs
@@ -1,0 +1,24 @@
+namespace DotnetPackaging.InstallerStub;
+
+public sealed class WelcomePageVM
+{
+    public WelcomePageVM(InstallerMetadata metadata)
+    {
+        Metadata = metadata;
+        Heading = $"Welcome to the {metadata.ApplicationName} Setup Wizard";
+        Description =
+            $"This wizard will guide you through the installation of {metadata.ApplicationName} version {metadata.Version}.";
+        AdditionalInfo =
+            string.IsNullOrWhiteSpace(metadata.Vendor)
+                ? null
+                : $"Publisher: {metadata.Vendor}";
+    }
+
+    public InstallerMetadata Metadata { get; }
+
+    public string Heading { get; }
+
+    public string Description { get; }
+
+    public string? AdditionalInfo { get; }
+}


### PR DESCRIPTION
## Summary
- add a dedicated welcome page view model and data template so the wizard opens on a welcome screen
- prepend the new welcome step to the wizard flow before destination selection
- switch the wizard builder configuration to the newer StepBuilder APIs to accommodate the welcome step

## Testing
- `dotnet test` *(fails: Microsoft.Build.Logging.TerminalLogger throws ArgumentOutOfRangeException)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db43cd968832f89052fed7d2b5661)