### PR TITLE
Load installer payload on view load

### DIFF
--- a/src/DotnetPackaging.InstallerStub/DotnetPackaging.InstallerStub.csproj
+++ b/src/DotnetPackaging.InstallerStub/DotnetPackaging.InstallerStub.csproj
@@ -31,17 +31,21 @@
 	  <Content Include="Assets\Icon.ico" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Include="Avalonia.Desktop" />
-	  <PackageReference Include="Avalonia.Fonts.Inter" />
-	  <PackageReference Include="Avalonia.Themes.Fluent" />
-	  <PackageReference Include="AvaloniaUI.DiagnosticsSupport" />
-	  <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" />
-	  <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" />
-	  <PackageReference Include="ReactiveUI.Avalonia" />
-	  <PackageReference Include="Zafiro.Avalonia" />
-	  <PackageReference Include="Zafiro" />
-	  <PackageReference Include="Zafiro.Avalonia.Dialogs" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="Avalonia.Desktop" />
+                <PackageReference Include="Avalonia.Fonts.Inter" />
+                <PackageReference Include="Avalonia.Themes.Fluent" />
+                <PackageReference Include="AvaloniaUI.DiagnosticsSupport" />
+                <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" />
+                <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" />
+                <PackageReference Include="ReactiveUI.Avalonia" />
+                <PackageReference Include="Zafiro.Avalonia" />
+                <PackageReference Include="Zafiro" />
+                <PackageReference Include="Zafiro.Avalonia.Dialogs" />
+        </ItemGroup>
+
+        <ItemGroup>
+                <ProjectReference Include="..\..\libs\Zafiro\src\Zafiro.DivineBytes\Zafiro.DivineBytes.csproj" />
+        </ItemGroup>
 
 </Project>

--- a/src/DotnetPackaging.InstallerStub/MainView.axaml
+++ b/src/DotnetPackaging.InstallerStub/MainView.axaml
@@ -9,7 +9,7 @@
     
     <Interaction.Behaviors>
         <LoadedTrigger>
-            <InvokeCommandAction Command="{Binding LoadWizard}" />
+            <InvokeCommandAction Command="{Binding LoadPayload}" />
         </LoadedTrigger>
     </Interaction.Behaviors>
     


### PR DESCRIPTION
## Summary
- load the installer payload before navigating the wizard so metadata and default paths are prepared up front
- restructure the payload extractor to return an InstallerPayload with both metadata and an IByteSource plus a helper to extract content once
- trigger the new command from the main view and add the DivineBytes project reference needed for the byte source type

## Testing
- dotnet build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd04e7e3c832fbb97034891c72fff)