### PR TITLE
Remove Fody weaver from installer stub

### DIFF
--- a/src/DotnetPackaging.InstallerStub/FodyWeavers.xml
+++ b/src/DotnetPackaging.InstallerStub/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <ReactiveUI />
-</Weavers>


### PR DESCRIPTION
## Summary
- remove the Fody weaver configuration from the installer stub project so it no longer runs ReactiveUI.Fody

## Testing
- dotnet build src/DotnetPackaging.InstallerStub/DotnetPackaging.InstallerStub.csproj

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7bc3647c832fb9e832223fb84834)