### PR TITLE
Pass contextual logger to command implementation

### DIFF
--- a/src/DotnetPackaging/Publish/DotnetPublisher.cs
+++ b/src/DotnetPackaging/Publish/DotnetPublisher.cs
@@ -19,7 +19,7 @@ public sealed class DotnetPublisher : IPublisher
     {
     }
 
-    public DotnetPublisher(Maybe<ILogger> logger) : this(new Command(logger), logger)
+    public DotnetPublisher(Maybe<ILogger> logger) : this(new Command(logger.Map(x => x.ForContext<Command>())), logger)
     {
     }
 


### PR DESCRIPTION
## Summary
- map the `DotnetPublisher` logger to a contextual `ForContext<Command>` instance when constructing the `ICommand` implementation so command execution logs include source context

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7b73d480832fb0113d38a017ee4b)