### PR TITLE
Fix EXE installer shortcut naming fallback

### DIFF
--- a/src/DotnetPackaging.Exe.Installer/Installer.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installer.cs
@@ -111,7 +111,8 @@ internal static class Installer
         try
         {
             var programs = Environment.GetFolderPath(Environment.SpecialFolder.Programs);
-            var lnkPath = Path.Combine(programs, $"{appName}.lnk");
+            var shortcutName = BuildShortcutName(appName, targetExe);
+            var lnkPath = Path.Combine(programs, $"{shortcutName}.lnk");
             Type shellType = Type.GetTypeFromProgID("WScript.Shell")!;
             dynamic shell = Activator.CreateInstance(shellType)!;
             dynamic shortcut = shell.CreateShortcut(lnkPath);
@@ -123,5 +124,19 @@ internal static class Installer
         {
             // Best-effort shortcut
         }
+    }
+
+    private static string BuildShortcutName(string appName, string targetExe)
+    {
+        var desiredName = string.IsNullOrWhiteSpace(appName)
+            ? Path.GetFileNameWithoutExtension(targetExe)
+            : appName.Trim();
+
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var sanitized = new string(desiredName.Where(character => !invalidCharacters.Contains(character)).ToArray());
+
+        return string.IsNullOrWhiteSpace(sanitized)
+            ? Path.GetFileNameWithoutExtension(targetExe)
+            : sanitized;
     }
 }


### PR DESCRIPTION
## Summary
- ensure the EXE installer generates shortcuts using a sanitized fallback when the application name is missing

## Testing
- dotnet test *(fails: missing Microsoft.NETCore.App 8.0.0 runtime)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0e60859c832f8a93d5be8aba8876)