### PR TITLE
Add Flatpak bundle integration test

### DIFF
--- a/DotnetPackaging.sln
+++ b/DotnetPackaging.sln
@@ -37,6 +37,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetPackaging.Exe.Install
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetPackaging.Exe", "src\DotnetPackaging.Exe\DotnetPackaging.Exe.csproj", "{E0875AD7-1D78-4FC3-EE2D-24AC1E066BFA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotnetPackaging.Flatpak.Tests", "test\DotnetPackaging.Flatpak.Tests\DotnetPackaging.Flatpak.Tests.csproj", "{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -191,6 +195,18 @@ Global
 		{E0875AD7-1D78-4FC3-EE2D-24AC1E066BFA}.Release|x64.Build.0 = Release|Any CPU
 		{E0875AD7-1D78-4FC3-EE2D-24AC1E066BFA}.Release|x86.ActiveCfg = Release|Any CPU
 		{E0875AD7-1D78-4FC3-EE2D-24AC1E066BFA}.Release|x86.Build.0 = Release|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Debug|x64.Build.0 = Debug|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Debug|x86.Build.0 = Debug|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Release|x64.ActiveCfg = Release|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Release|x64.Build.0 = Release|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Release|x86.ActiveCfg = Release|Any CPU
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -198,6 +214,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{79928283-5F6E-49F4-ACC4-FE5994DA1116} = {F33ABB7A-E6A3-4F45-BFB5-9A014B8C5F12}
 		{DF914DC0-903B-4733-8F85-45F733F2DE5F} = {F33ABB7A-E6A3-4F45-BFB5-9A014B8C5F12}
+		{F090C5BD-3B1C-4D32-93AD-5D90E4819A69} = {F33ABB7A-E6A3-4F45-BFB5-9A014B8C5F12}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D869DF1-9147-472D-A3D9-D519518A6951}

--- a/test/DotnetPackaging.Flatpak.Tests/DotnetPackaging.Flatpak.Tests.csproj
+++ b/test/DotnetPackaging.Flatpak.Tests/DotnetPackaging.Flatpak.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="CSharpFunctionalExtensions.FluentAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/test/DotnetPackaging.Flatpak.Tests/FlatpakFromProjectTests.cs
+++ b/test/DotnetPackaging.Flatpak.Tests/FlatpakFromProjectTests.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+
+namespace DotnetPackaging.Flatpak.Tests;
+
+public sealed class FlatpakFromProjectTests
+{
+    private const string AppId = "com.example.dotnetpackaging.tool";
+
+    [Fact]
+    public async Task DotnetPackagingTool_bundle_passes_flatpak_validation()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            throw new XunitException("Flatpak validation requires Linux.");
+        }
+
+        Assert.True(CommandExists("flatpak"), "Flatpak CLI is required to verify bundles.");
+        Assert.True(CommandExists("ostree"), "ostree CLI is required to inspect bundle contents.");
+
+        using var temp = new TempDirectory();
+        var repoRoot = GetRepositoryRoot();
+        var projectPath = Path.Combine(repoRoot, "src", "DotnetPackaging.Tool", "DotnetPackaging.Tool.csproj");
+        var bundlePath = Path.Combine(temp.Path, "DotnetPackaging.Tool.flatpak");
+        var repoPath = Path.Combine(temp.Path, "repo");
+        var checkoutPath = Path.Combine(temp.Path, "checkout");
+
+        Directory.CreateDirectory(repoPath);
+
+        var environment = new Dictionary<string, string>
+        {
+            ["DOTNET_ROLL_FORWARD"] = "Major",
+        };
+
+        await Execute(
+            "dotnet",
+            $"run --project \"{projectPath}\" -- flatpak from-project --project \"{projectPath}\" --output \"{bundlePath}\" --system",
+            repoRoot,
+            environment);
+
+        File.Exists(bundlePath).Should().BeTrue("the CLI should produce a Flatpak bundle");
+
+        await Execute("ostree", $"init --mode=archive-z2 --repo=\"{repoPath}\"");
+        await Execute("flatpak", $"build-import-bundle \"{repoPath}\" \"{bundlePath}\"");
+        await Execute("ostree", $"checkout --repo=\"{repoPath}\" app/{AppId}/x86_64/stable \"{checkoutPath}\"");
+
+        var metadataPath = Path.Combine(checkoutPath, "metadata");
+        File.Exists(metadataPath).Should().BeTrue();
+        var metadata = await File.ReadAllTextAsync(metadataPath);
+        metadata.Should().Contain($"name={AppId}");
+        metadata.Should().Contain("runtime=org.freedesktop.Platform/x86_64/23.08");
+        metadata.Should().Contain($"command={AppId}");
+
+        var desktopPath = Path.Combine(checkoutPath, "export", "share", "applications", $"{AppId}.desktop");
+        File.Exists(desktopPath).Should().BeTrue();
+
+        var metainfoPath = Path.Combine(checkoutPath, "export", "share", "metainfo", $"{AppId}.metainfo.xml");
+        File.Exists(metainfoPath).Should().BeTrue();
+
+        var wrapperPath = Path.Combine(checkoutPath, "files", "bin", AppId);
+        File.Exists(wrapperPath).Should().BeTrue();
+
+        var executablePath = Path.Combine(checkoutPath, "files", "DotnetPackaging.Tool");
+        File.Exists(executablePath).Should().BeTrue();
+
+        var managedAssembly = Path.Combine(checkoutPath, "files", "DotnetPackaging.dll");
+        File.Exists(managedAssembly).Should().BeTrue();
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        var directory = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(directory))
+        {
+            var solutionPath = Path.Combine(directory, "DotnetPackaging.sln");
+            if (File.Exists(solutionPath))
+            {
+                return directory;
+            }
+
+            directory = Directory.GetParent(directory)?.FullName ?? string.Empty;
+        }
+
+        throw new InvalidOperationException("Could not locate the repository root.");
+    }
+
+    private static async Task<CommandResult> Execute(
+        string fileName,
+        string arguments,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environment = null)
+    {
+        var startInfo = new ProcessStartInfo(fileName, arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        if (!string.IsNullOrEmpty(workingDirectory))
+        {
+            startInfo.WorkingDirectory = workingDirectory;
+        }
+
+        if (environment is not null)
+        {
+            foreach (var pair in environment)
+            {
+                startInfo.Environment[pair.Key] = pair.Value;
+            }
+        }
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Unable to start '{fileName}'.");
+        var stdOutTask = process.StandardOutput.ReadToEndAsync();
+        var stdErrTask = process.StandardError.ReadToEndAsync();
+        await Task.WhenAll(stdOutTask, stdErrTask, process.WaitForExitAsync());
+
+        if (process.ExitCode != 0)
+        {
+            throw new XunitException(
+                $"Command '{fileName} {arguments}' failed with exit code {process.ExitCode}.{Environment.NewLine}{stdOutTask.Result}{stdErrTask.Result}");
+        }
+
+        return new CommandResult(stdOutTask.Result, stdErrTask.Result);
+    }
+
+    private static bool CommandExists(string commandName)
+    {
+        var pathValue = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(pathValue))
+        {
+            return false;
+        }
+
+        var suffixes = OperatingSystem.IsWindows()
+            ? new[] { ".exe", ".bat", ".cmd" }
+            : new[] { string.Empty };
+
+        foreach (var path in pathValue.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var suffix in suffixes)
+            {
+                var candidate = Path.Combine(path, commandName + suffix);
+                if (File.Exists(candidate))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private sealed record CommandResult(string StandardOutput, string StandardError);
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "DotnetPackaging.Flatpak.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Directory.Exists(Path))
+                {
+                    Directory.Delete(Path, true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup failures
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DotnetPackaging.Flatpak.Tests project covering the CLI flatpak from-project flow
- verify the generated bundle with flatpak build-import-bundle and inspect its contents via ostree
- register the new test project in the solution

## Testing
- dotnet test test/DotnetPackaging.Flatpak.Tests/DotnetPackaging.Flatpak.Tests.csproj

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158ad6f240832f83e2c3ac11a29e16)