### PR TITLE
Add uninstall flow to installer stub

### DIFF
--- a/src/DotnetPackaging.Exe.Installer/App.axaml.cs
+++ b/src/DotnetPackaging.Exe.Installer/App.axaml.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
 using System.IO.Compression;
+using System.Linq;
 using System.Text.Json;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using DotnetPackaging.Exe.Installer.Core;
+using DotnetPackaging.Exe.Installer.Uninstallation;
 using Projektanker.Icons.Avalonia;
 using Projektanker.Icons.Avalonia.FontAwesome;
 using Projektanker.Icons.Avalonia.MaterialDesign;
@@ -28,8 +31,15 @@ public sealed class App : Application
             return;
         }
 
-        if (ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime)
+        if (ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktopLifetime)
         {
+            return;
+        }
+
+        var args = desktopLifetime.Args ?? Array.Empty<string>();
+        if (IsUninstallMode(args))
+        {
+            await Uninstallation.Uninstallation.Launch();
             return;
         }
 
@@ -96,4 +106,7 @@ public sealed class App : Application
             return true;
         }
     }
+
+    private static bool IsUninstallMode(IEnumerable<string> args)
+        => args.Any(arg => string.Equals(arg, "--uninstall", StringComparison.OrdinalIgnoreCase));
 }

--- a/src/DotnetPackaging.Exe.Installer/Core/InstallationRegistry.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/InstallationRegistry.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Exe.Installer.Core;
+
+internal static class InstallationRegistry
+{
+    private static readonly object Gate = new();
+
+    public static Result Register(InstallationResult installation)
+    {
+        return Result.Try(() =>
+        {
+            lock (Gate)
+            {
+                Directory.CreateDirectory(GetRegistryDirectory());
+                var path = GetRegistryPath(installation.Metadata.AppId);
+                var record = new RegisteredInstallation(
+                    installation.Metadata.AppId,
+                    installation.Metadata.ApplicationName,
+                    installation.Metadata.Vendor,
+                    installation.Metadata.Version,
+                    installation.InstallDirectory,
+                    installation.ExecutablePath);
+                var json = JsonSerializer.Serialize(record);
+                File.WriteAllText(path, json);
+            }
+        }, ex => $"Failed to register installation: {ex.Message}");
+    }
+
+    public static Result<RegisteredInstallation> Get(string appId)
+    {
+        return Result.Try(() =>
+        {
+            lock (Gate)
+            {
+                var path = GetRegistryPath(appId);
+                if (!File.Exists(path))
+                {
+                    throw new FileNotFoundException($"Installation record for '{appId}' was not found.", path);
+                }
+
+                var json = File.ReadAllText(path);
+                var record = JsonSerializer.Deserialize<RegisteredInstallation>(json);
+                return record ?? throw new InvalidOperationException($"Installation record for '{appId}' is invalid.");
+            }
+        }, ex => $"Failed to read installation information: {ex.Message}");
+    }
+
+    public static Result Remove(string appId)
+    {
+        return Result.Try(() =>
+        {
+            lock (Gate)
+            {
+                var path = GetRegistryPath(appId);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }, ex => $"Failed to remove installation information: {ex.Message}");
+    }
+
+    private static string GetRegistryDirectory()
+    {
+        var baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(baseDirectory, "DotnetPackaging", "Installations");
+    }
+
+    private static string GetRegistryPath(string appId)
+    {
+        var directory = GetRegistryDirectory();
+        var fileName = BuildFileName(appId);
+        return Path.Combine(directory, fileName);
+    }
+
+    private static string BuildFileName(string appId)
+    {
+        if (string.IsNullOrWhiteSpace(appId))
+        {
+            return "default.json";
+        }
+
+        var invalidCharacters = Path.GetInvalidFileNameChars();
+        var sanitized = new string(appId.Select(character => invalidCharacters.Contains(character) ? '_' : character).ToArray());
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(appId));
+            sanitized = Convert.ToHexString(hash)[..16];
+        }
+
+        return sanitized + ".json";
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Core/RegisteredInstallation.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/RegisteredInstallation.cs
@@ -1,0 +1,9 @@
+namespace DotnetPackaging.Exe.Installer.Core;
+
+public sealed record RegisteredInstallation(
+    string AppId,
+    string ApplicationName,
+    string Vendor,
+    string Version,
+    string InstallDirectory,
+    string ExecutablePath);

--- a/src/DotnetPackaging.Exe.Installer/Core/UninstallationResult.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/UninstallationResult.cs
@@ -1,0 +1,3 @@
+namespace DotnetPackaging.Exe.Installer.Core;
+
+public sealed record UninstallationResult(InstallerMetadata Metadata, string InstallDirectory);

--- a/src/DotnetPackaging.Exe.Installer/Core/Uninstaller.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/Uninstaller.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Exe.Installer.Core;
+
+internal static class Uninstaller
+{
+    public static Result<UninstallationResult> Uninstall(InstallerMetadata metadata, RegisteredInstallation installation)
+    {
+        return Result.Try(() =>
+            {
+                RemoveInstallationDirectory(installation.InstallDirectory);
+                ShortcutService.TryDeleteDesktopShortcut(metadata.ApplicationName, installation.ExecutablePath);
+                ShortcutService.TryDeleteStartMenuShortcut(metadata.ApplicationName, installation.ExecutablePath);
+                return new UninstallationResult(metadata, installation.InstallDirectory);
+            }, ex => $"Failed to uninstall application: {ex.Message}")
+            .Bind(result => InstallationRegistry.Remove(metadata.AppId).Map(() => result));
+    }
+
+    private static void RemoveInstallationDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        Directory.Delete(path, true);
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Install/InstallViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Install/InstallViewModel.cs
@@ -33,7 +33,8 @@ public class InstallViewModel
             }
 
             return Core.Installer.Install(installDirectory, installerMetadata)
-                .Map(exePath => new InstallationResult(installerMetadata, installDirectory, exePath));
+                .Map(exePath => new InstallationResult(installerMetadata, installDirectory, exePath))
+                .Bind(result => InstallationRegistry.Register(result).Map(() => result));
         });
     }
 

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Uninstallation.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Uninstallation.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using DotnetPackaging.Exe.Installer.Core;
+using DotnetPackaging.Exe.Installer.Uninstallation.Wizard;
+using Zafiro.Avalonia.Dialogs.Implementations;
+using Zafiro.Avalonia.Dialogs.Wizards.Slim;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation;
+
+internal static class Uninstallation
+{
+    public static async Task Launch()
+    {
+        var currentApp = App.Current;
+        if (currentApp?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktopLifetime)
+        {
+            return;
+        }
+
+        try
+        {
+            var root = CreateRootWindow();
+            desktopLifetime.MainWindow = root;
+            root.Show();
+
+            var dialog = new DesktopDialog();
+            var payload = new DefaultInstallerPayload();
+            var wizard = new UninstallWizard(payload).CreateWizard();
+
+            var title = await ResolveWindowTitle(payload);
+            await wizard.ShowInDialog(dialog, title);
+
+            desktopLifetime.Shutdown();
+        }
+        catch (Exception ex)
+        {
+            TryWriteCrashLog(ex);
+            throw;
+        }
+    }
+
+    private static Window CreateRootWindow()
+        => new()
+        {
+            Width = 1,
+            Height = 1,
+            Opacity = 0,
+            WindowStartupLocation = WindowStartupLocation.CenterScreen,
+            CanResize = false,
+            SystemDecorations = SystemDecorations.None,
+            ShowInTaskbar = false
+        };
+
+    private static async Task<string> ResolveWindowTitle(DefaultInstallerPayload payload)
+    {
+        var metaResult = await payload.GetMetadata();
+        var title = metaResult.IsSuccess && !string.IsNullOrWhiteSpace(metaResult.Value.ApplicationName)
+            ? $"{metaResult.Value.ApplicationName} Uninstaller"
+            : "Uninstaller";
+
+        return title;
+    }
+
+    private static void TryWriteCrashLog(Exception ex)
+    {
+        try
+        {
+            var log = Path.Combine(Path.GetTempPath(), "dp-installer-stub-error.txt");
+            File.WriteAllText(log, ex.ToString());
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Finish/UninstallFinishedView.axaml
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Finish/UninstallFinishedView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:finish="clr-namespace:DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Finish"
+             mc:Ignorable="d"
+             x:Class="DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Finish.UninstallFinishedView"
+             x:DataType="finish:UninstallFinishedViewModel">
+    <StackPanel Spacing="10">
+        <TextBlock TextWrapping="Wrap"
+                   Text="{Binding Result.Metadata.ApplicationName, StringFormat='{}{0} was removed successfully.'}" />
+        <TextBlock TextWrapping="Wrap"
+                   Text="{Binding Result.InstallDirectory, StringFormat='Removed from {0}'}" />
+        <TextBlock>Click Close to exit.</TextBlock>
+    </StackPanel>
+</UserControl>

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Finish/UninstallFinishedView.axaml.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Finish/UninstallFinishedView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Finish;
+
+public partial class UninstallFinishedView : UserControl
+{
+    public UninstallFinishedView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Finish/UninstallFinishedViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Finish/UninstallFinishedViewModel.cs
@@ -1,0 +1,27 @@
+using System.Reactive;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using DotnetPackaging.Exe.Installer.Core;
+using ReactiveUI;
+using Zafiro.UI.Commands;
+using CFE = CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Finish;
+
+public sealed class UninstallFinishedViewModel
+{
+    public UninstallFinishedViewModel(UninstallationResult result)
+    {
+        Result = result;
+        Close = ReactiveCommand
+            .CreateFromTask<Unit, CFE.Result<UninstallationResult>>(_ => Task.FromResult(ExecuteClose()))
+            .Enhance();
+    }
+
+    public UninstallationResult Result { get; }
+
+    public IEnhancedCommand<CFE.Result<UninstallationResult>> Close { get; }
+
+    private CFE.Result<UninstallationResult> ExecuteClose()
+        => CFE.Result.Success(Result);
+}

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Steps/UninstallView.axaml
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Steps/UninstallView.axaml
@@ -1,0 +1,23 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:steps="clr-namespace:DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Steps"
+             mc:Ignorable="d"
+             x:Class="DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Steps.UninstallView"
+             x:DataType="steps:UninstallViewModel">
+    <StackPanel Spacing="10">
+        <TextBlock TextWrapping="Wrap"
+                   Text="{Binding ApplicationName, StringFormat='Click Uninstall to remove {0} and delete its shortcuts.'}" />
+
+        <StackPanel Spacing="4" IsVisible="{Binding CanUninstall}">
+            <TextBlock FontWeight="Bold">Installation directory</TextBlock>
+            <TextBlock Text="{Binding InstallDirectory}" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Border Background="#22ff0000" Padding="8" CornerRadius="4" IsVisible="{Binding InstallationMissing}">
+            <TextBlock TextWrapping="Wrap"
+                       Text="{Binding ErrorMessage, StringFormat='Unable to locate an installation for this package: {0}'}" />
+        </Border>
+    </StackPanel>
+</UserControl>

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Steps/UninstallView.axaml.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Steps/UninstallView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Steps;
+
+public partial class UninstallView : UserControl
+{
+    public UninstallView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Steps/UninstallViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Steps/UninstallViewModel.cs
@@ -1,0 +1,57 @@
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
+using DotnetPackaging.Exe.Installer.Core;
+using ReactiveUI;
+using Zafiro.UI.Commands;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Steps;
+
+public class UninstallViewModel
+{
+    private readonly InstallerMetadata metadata;
+    private readonly RegisteredInstallation? installation;
+
+    public UninstallViewModel(InstallerMetadata metadata)
+    {
+        this.metadata = metadata;
+        var installationResult = InstallationRegistry.Get(metadata.AppId);
+        if (installationResult.IsSuccess)
+        {
+            installation = installationResult.Value;
+        }
+        else
+        {
+            ErrorMessage = installationResult.Error;
+        }
+
+        CanUninstall = installationResult.IsSuccess;
+        var canExecute = Observable.Return(CanUninstall);
+        Uninstall = ReactiveCommand.CreateFromTask(ExecuteUninstall, canExecute).Enhance();
+    }
+
+    public string? InstallDirectory => installation?.InstallDirectory;
+
+    public string? ErrorMessage { get; }
+
+    public string ApplicationName => metadata.ApplicationName;
+
+    public bool CanUninstall { get; }
+
+    public bool InstallationMissing => !CanUninstall;
+
+    public IEnhancedCommand<Result<UninstallationResult>> Uninstall { get; }
+
+    private Task<Result<UninstallationResult>> ExecuteUninstall()
+    {
+        return Task.Run(() =>
+        {
+            if (installation is null)
+            {
+                return Result.Failure<UninstallationResult>(ErrorMessage ?? "Installation not found.");
+            }
+
+            return Uninstaller.Uninstall(metadata, installation);
+        });
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/UninstallWizard.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/UninstallWizard.cs
@@ -1,0 +1,31 @@
+using DotnetPackaging.Exe.Installer.Core;
+using DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Finish;
+using DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Steps;
+using DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Welcome;
+using Zafiro.UI.Commands;
+using Zafiro.UI.Wizards.Slim;
+using Zafiro.UI.Wizards.Slim.Builder;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard;
+
+public class UninstallWizard
+{
+    private readonly IInstallerPayload payload;
+
+    public UninstallWizard(IInstallerPayload payload)
+    {
+        this.payload = payload;
+    }
+
+    public SlimWizard<UninstallationResult> CreateWizard()
+    {
+        var welcome = new UninstallWelcomeViewModel(payload);
+
+        return WizardBuilder
+            .StartWith(() => welcome, "")
+            .Next(w => w.Metadata.Value!).WhenValid()
+            .Then(meta => new UninstallViewModel(meta), "Uninstall").NextCommand(vm => vm.Uninstall.Enhance("Uninstall"))
+            .Then(result => new UninstallFinishedViewModel(result), "Finished").NextCommand(vm => vm.Close.Enhance("Close"))
+            .WithCompletionFinalStep();
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeView.axaml
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeView.axaml
@@ -1,0 +1,26 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:welcome="clr-namespace:DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Welcome"
+             mc:Ignorable="d"
+             x:Class="DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Welcome.UninstallWelcomeView"
+             x:DataType="welcome:UninstallWelcomeViewModel">
+    <Interaction.Behaviors>
+        <LoadedTrigger>
+            <InvokeCommandAction Command="{Binding LoadMetadata}" />
+        </LoadedTrigger>
+    </Interaction.Behaviors>
+
+    <Loading IsLoading="{Binding LoadMetadata.IsExecuting^}">
+        <DockPanel VerticalSpacing="12">
+            <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Text="{Binding Metadata.Value.ApplicationName, StringFormat='Welcome to the {0} uninstallation wizard'}" FontSize="20" FontWeight="Bold" />
+            <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Right" Text="{Binding Metadata.Value.Version, StringFormat='Version {0}'}" />
+            <TextBlock DockPanel.Dock="Top" Text="{Binding Metadata.Value.ApplicationName, StringFormat='This wizard will help you remove {0} from this system'}" />
+
+            <StackPanel Spacing="12" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock>Click Next to continue</TextBlock>
+            </StackPanel>
+        </DockPanel>
+    </Loading>
+</UserControl>

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeView.axaml.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Welcome;
+
+public partial class UninstallWelcomeView : UserControl
+{
+    public UninstallWelcomeView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeViewModel.cs
@@ -1,0 +1,29 @@
+using System.Reactive;
+using CSharpFunctionalExtensions;
+using DotnetPackaging.Exe.Installer.Core;
+using ReactiveUI;
+using ReactiveUI.Validation.Extensions;
+using ReactiveUI.Validation.Helpers;
+using Zafiro.CSharpFunctionalExtensions;
+using Zafiro.UI;
+
+namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Welcome;
+
+public sealed class UninstallWelcomeViewModel : ReactiveValidationObject, IValidatable
+{
+    private readonly IInstallerPayload payload;
+
+    public UninstallWelcomeViewModel(IInstallerPayload payload)
+    {
+        this.payload = payload;
+        LoadMetadata = ReactiveCommand.CreateFromTask(() => this.payload.GetMetadata());
+        Metadata = new Reactive.Bindings.ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
+        this.ValidationRule(model => model.Metadata.Value, m => m is not null, "Metadata is required");
+    }
+
+    public Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
+
+    public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+
+    public IObservable<bool> IsValid => this.IsValid();
+}


### PR DESCRIPTION
## Summary
- detect the `--uninstall` argument at startup and route to a dedicated wizard flow
- persist installation metadata and expose shortcut deletion helpers so the uninstaller can remove files and shortcuts safely
- add the uninstall wizard UI plus supporting registry/uninstaller services to delete the app directory and clear the recorded installation

## Testing
- dotnet build src/DotnetPackaging.Exe.Installer/DotnetPackaging.Exe.Installer.csproj -c Release

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3c267730832fb0c46a3bd8f2b178)