### PR TITLE
Allow CLI to roll forward to newer runtimes

### DIFF
--- a/src/DotnetPackaging.Tool/DotnetPackaging.Tool.csproj
+++ b/src/DotnetPackaging.Tool/DotnetPackaging.Tool.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
## Summary
- configure the dotnet tool project to roll forward to the latest available major runtime so it can run on machines that only have newer SDKs installed

## Testing
- dotnet build DotnetPackaging.sln -c Release

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3ff2348c832fbad6833591486753)