### PR TITLE
Remove Projektanker icon dependencies from installer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,8 +18,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NyaFs" Version="1.0.8" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
-    <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.6.2" />
-    <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.6.2" />
     <PackageVersion Include="ReactiveProperty" Version="9.8.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="11.3.8" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />

--- a/src/DotnetPackaging.Exe.Installer/App.axaml.cs
+++ b/src/DotnetPackaging.Exe.Installer/App.axaml.cs
@@ -7,9 +7,6 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using DotnetPackaging.Exe.Installer.Core;
 using DotnetPackaging.Exe.Installer.Uninstallation;
-using Projektanker.Icons.Avalonia;
-using Projektanker.Icons.Avalonia.FontAwesome;
-using Projektanker.Icons.Avalonia.MaterialDesign;
 using Zafiro.DivineBytes;
 
 namespace DotnetPackaging.Exe.Installer;
@@ -23,8 +20,6 @@ public sealed class App : Application
 
     public override async void OnFrameworkInitializationCompleted()
     {
-        RegisterIcons();
-
         if (TryHandleMetadataDump())
         {
             (ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)?.Shutdown();
@@ -44,13 +39,6 @@ public sealed class App : Application
         }
 
         await Installation.Installation.Launch();
-    }
-
-    private static void RegisterIcons()
-    {
-        IconProvider.Current
-            .Register<FontAwesomeIconProvider>()
-            .Register<MaterialDesignIconProvider>();
     }
 
     private static bool TryHandleMetadataDump()

--- a/src/DotnetPackaging.Exe.Installer/DotnetPackaging.Exe.Installer.csproj
+++ b/src/DotnetPackaging.Exe.Installer/DotnetPackaging.Exe.Installer.csproj
@@ -33,8 +33,6 @@
         <PackageReference Include="Avalonia.Themes.Fluent" />
         <PackageReference Include="AvaloniaUI.DiagnosticsSupport" />
         <PackageReference Include="ByteSize" />
-        <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" />
-        <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" />
         <PackageReference Include="ReactiveProperty" />
         <PackageReference Include="ReactiveUI.Avalonia" />
         <PackageReference Include="Zafiro.Avalonia" />


### PR DESCRIPTION
## Summary
- remove the Projektanker icon packages from the central package list and the installer stub so the dependency is no longer pulled
- delete the installer bootstrapper code that registered the Projektanker icon providers

## Testing
- dotnet build DotnetPackaging.sln

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b95c368e4832f98f892c14721de6a)