### PR TITLE
Make uninstaller payloadless and enable stub compression

### DIFF
--- a/src/DotnetPackaging.Exe.Installer/Core/UninstallerBuilder.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/UninstallerBuilder.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using CSharpFunctionalExtensions;
+using Serilog;
+
+namespace DotnetPackaging.Exe.Installer.Core;
+
+internal static class UninstallerBuilder
+{
+    public static Result<string> CreatePayloadlessUninstaller(string installerPath, string destinationPath)
+    {
+        try
+        {
+            if (!File.Exists(installerPath))
+            {
+                return Result.Failure<string>($"Installer path not found: {installerPath}");
+            }
+
+            File.Copy(installerPath, destinationPath, overwrite: true);
+
+            var payloadStart = PayloadExtractor.GetAppendedPayloadStart(destinationPath);
+            if (payloadStart.HasValue)
+            {
+                using var stream = File.Open(destinationPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                stream.SetLength(payloadStart.Value);
+                Log.Information("Embedded payload stripped from uninstaller at {Path}", destinationPath);
+            }
+            else
+            {
+                Log.Information("No appended payload detected in installer. Uninstaller kept intact at {Path}", destinationPath);
+            }
+
+            return Result.Success(destinationPath);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to create payloadless uninstaller");
+            return Result.Failure<string>($"Failed to create payloadless uninstaller: {ex.Message}");
+        }
+    }
+}

--- a/src/DotnetPackaging.Exe/ExePackagingService.cs
+++ b/src/DotnetPackaging.Exe/ExePackagingService.cs
@@ -356,13 +356,13 @@ public sealed class ExePackagingService
             Configuration = "Release",
             SingleFile = true,
             Trimmed = false,
-            MsBuildProperties = new Dictionary<string, string>
+                MsBuildProperties = new Dictionary<string, string>
             {
                 ["IncludeNativeLibrariesForSelfExtract"] = "true",
                 ["IncludeAllContentForSelfExtract"] = "true",
                 ["PublishTrimmed"] = "false",
                 ["DebugType"] = "embedded",
-                ["EnableCompressionInSingleFile"] = "false"
+                ["EnableCompressionInSingleFile"] = "true"
             }
         };
 


### PR DESCRIPTION
## Summary
- strip the embedded payload when producing Uninstall.exe and persist installer metadata for the stripped stub
- add a dedicated uninstaller builder to remove appended payload data while keeping a single executable
- enable compression when publishing the installer single-file stub to reduce its size

## Testing
- dotnet test *(fails: Flatpak CLI is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4e2bf0a4832fbc05a5f8a51d08f2)