### PR TITLE
Add skippable facts support to installer tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,5 +58,6 @@
     <PackageVersion Include="Zafiro.FileSystem.Local" Version="41.2.1" />
     <PackageVersion Include="Zafiro.DivineBytes" Version="41.2.4" />
     <PackageVersion Include="DiscUtils" Version="0.16.13" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 </Project>

--- a/src/DotnetPackaging.Exe.Tests/DotnetPackaging.Exe.Tests.csproj
+++ b/src/DotnetPackaging.Exe.Tests/DotnetPackaging.Exe.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotnetPackaging.Exe.Tests/SimpleExePackerTests.cs
+++ b/src/DotnetPackaging.Exe.Tests/SimpleExePackerTests.cs
@@ -7,13 +7,12 @@ using DotnetPackaging.Exe;
 using DotnetPackaging.Exe.Installer.Core;
 using FluentAssertions;
 using Xunit;
-using Xunit.Sdk;
 
 namespace DotnetPackaging.Exe.Tests;
 
 public class SimpleExePackerTests
 {
-    [Fact]
+    [SkippableFact]
     public async Task Should_Create_Valid_Uninstaller_By_Stripping_Payload()
     {
         Skip.IfNot(OperatingSystem.IsWindows(), "Installer stub is Windows-only.");
@@ -77,7 +76,7 @@ public class SimpleExePackerTests
         try { Directory.Delete(tempDir.FullName, true); } catch { }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Should_Extract_Payload_Correctly_From_Installer()
     {
         Skip.IfNot(OperatingSystem.IsWindows(), "Installer stub is Windows-only.");
@@ -140,7 +139,7 @@ public class SimpleExePackerTests
         try { Directory.Delete(tempDir.FullName, true); } catch { }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Installer_build_should_produce_bootable_executable()
     {
         Skip.IfNot(OperatingSystem.IsWindows(), "Installer stub is Windows-only.");
@@ -181,7 +180,7 @@ public class SimpleExePackerTests
         try { Directory.Delete(tempDir.FullName, true); } catch { }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Uninstaller_should_be_stripped_and_bootable()
     {
         Skip.IfNot(OperatingSystem.IsWindows(), "Installer stub is Windows-only.");
@@ -235,7 +234,7 @@ public class SimpleExePackerTests
         try { Directory.Delete(tempDir.FullName, true); } catch { }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Dispatcher_failures_should_be_logged()
     {
         Skip.IfNot(OperatingSystem.IsWindows(), "Installer stub is Windows-only.");


### PR DESCRIPTION
## Summary
- add the Xunit.SkippableFact package to the installer test project
- mark the installer integration tests as skippable facts so Skip helper is available

## Testing
- dotnet build -v minimal


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f77dfd4a4832f98d245ff8420d799)