### PR TITLE
Record payload size in uninstall registry

### DIFF
--- a/src/DotnetPackaging.Exe.Installer/Core/DefaultInstallerPayload.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/DefaultInstallerPayload.cs
@@ -11,6 +11,9 @@ public sealed class DefaultInstallerPayload : IInstallerPayload
     public Task<Result<InstallerMetadata>> GetMetadata(CancellationToken ct = default)
         => EnsureLoaded(ct).Map(p => p.Metadata);
 
+    public Task<Result<long>> GetContentSize(CancellationToken ct = default)
+        => EnsureLoaded(ct).Map(p => p.ContentSizeBytes);
+
     public Task<Result> CopyContents(string targetDirectory, IObserver<Progress>? progressObserver = null, CancellationToken ct = default)
         => EnsureLoaded(ct).Bind(p => Task.Run(() =>
             PayloadExtractor.CopyContentTo(p, targetDirectory, progressObserver), ct));

--- a/src/DotnetPackaging.Exe.Installer/Core/IInstallerPayload.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/IInstallerPayload.cs
@@ -7,6 +7,8 @@ public interface IInstallerPayload
 {
     Task<Result<InstallerMetadata>> GetMetadata(CancellationToken ct = default);
 
+    Task<Result<long>> GetContentSize(CancellationToken ct = default);
+
     Task<Result> CopyContents(
         string targetDirectory,
         IObserver<Progress>? progressObserver = null,

--- a/src/DotnetPackaging.Exe.Installer/Core/Installer.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/Installer.cs
@@ -6,14 +6,14 @@ namespace DotnetPackaging.Exe.Installer.Core;
 
 internal static class Installer
 {
-    public static Result<string> Install(string targetDir, InstallerMetadata meta)
+    public static Result<string> Install(string targetDir, InstallerMetadata meta, long payloadSizeBytes)
     {
         return ResolveMainExe(targetDir, meta)
             .Tap(exePath => ShortcutService.TryCreateStartMenuShortcut(meta.ApplicationName, exePath))
-            .Tap(exePath => RegisterUninstaller(targetDir, meta, exePath));
+            .Tap(exePath => RegisterUninstaller(targetDir, meta, exePath, payloadSizeBytes));
     }
 
-    private static void RegisterUninstaller(string targetDir, InstallerMetadata meta, string mainExePath)
+    private static void RegisterUninstaller(string targetDir, InstallerMetadata meta, string mainExePath, long payloadSizeBytes)
     {
         if (Environment.ProcessPath is null)
         {
@@ -44,11 +44,12 @@ internal static class Installer
             WindowsRegistryService.Register(
                 meta.AppId,
                 meta.ApplicationName,
-                meta.Version, 
-                meta.Vendor, 
-                targetDir, 
-                $"\"{uninstallerPath}\" --uninstall", 
-                mainExePath);
+                meta.Version,
+                meta.Vendor,
+                targetDir,
+                $"\"{uninstallerPath}\" --uninstall",
+                mainExePath,
+                payloadSizeBytes);
         }
         catch (Exception ex)
         {

--- a/src/DotnetPackaging.Exe.Installer/Core/MetadataFilePayload.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/MetadataFilePayload.cs
@@ -49,6 +49,11 @@ internal sealed class MetadataFilePayload : IInstallerPayload
         }, ex => $"Failed to read metadata: {ex.Message}"));
     }
 
+    public Task<Result<long>> GetContentSize(CancellationToken ct = default)
+    {
+        return Task.FromResult(Result.Failure<long>("Disk-only payload does not provide installation content."));
+    }
+
     public Task<Result> CopyContents(string targetDirectory, IObserver<Progress>? progressObserver = null, CancellationToken ct = default)
     {
         return Task.FromResult(Result.Failure("Disk-only payload does not provide installation content."));

--- a/src/DotnetPackaging.Exe.Installer/Core/WindowsRegistryService.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/WindowsRegistryService.cs
@@ -10,7 +10,7 @@ internal static class WindowsRegistryService
 {
     private const string UninstallKey = @"Software\Microsoft\Windows\CurrentVersion\Uninstall";
 
-    public static Result Register(string appId, string applicationName, string version, string publisher, string installLocation, string uninstallString, string displayIcon)
+    public static Result Register(string appId, string applicationName, string version, string publisher, string installLocation, string uninstallString, string displayIcon, long estimatedSizeBytes)
     {
         return Result.Try(() =>
         {
@@ -23,6 +23,12 @@ internal static class WindowsRegistryService
             key.SetValue("DisplayIcon", displayIcon);
             key.SetValue("NoModify", 1);
             key.SetValue("NoRepair", 1);
+
+            if (estimatedSizeBytes > 0)
+            {
+                var estimatedSizeKb = (int)Math.Clamp((estimatedSizeBytes + 1023) / 1024, 1, int.MaxValue);
+                key.SetValue("EstimatedSize", estimatedSizeKb, RegistryValueKind.DWord);
+            }
         }, ex => $"Failed to create registry keys: {ex.Message}");
     }
 

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/InstallWizard.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/InstallWizard.cs
@@ -53,7 +53,7 @@ public class InstallWizard
     {
         return Task.Run(() =>
             PayloadExtractor.CopyContentTo(payload, installDir, progressObserver)
-                .Bind(() => Core.Installer.Install(installDir, payload.Metadata))
+                .Bind(() => Core.Installer.Install(installDir, payload.Metadata, payload.ContentSizeBytes))
                 .Map(exePath => new InstallationResult(payload.Metadata, installDir, exePath)));
     }
     


### PR DESCRIPTION
## Summary
- add payload size tracking from installer payloads and report it to Windows uninstall registry entries
- expose payload size through installer payload abstractions for reuse during installation

## Testing
- dotnet test (fails: missing Flatpak CLI / logger exception)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f8878c4c0832fbed5255a2e846707)