### PR TITLE
Add wizard logo support for Windows installers

### DIFF
--- a/src/DotnetPackaging.Exe.Installer/Core/BrandingLogoFactory.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/BrandingLogoFactory.cs
@@ -1,0 +1,25 @@
+using Avalonia.Media.Imaging;
+using Zafiro.DivineBytes;
+
+namespace DotnetPackaging.Exe.Installer.Core;
+
+internal static class BrandingLogoFactory
+{
+    public static IBitmap? FromBytes(IByteSource? bytes)
+    {
+        if (bytes is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = bytes.ToStreamSeekable();
+            return new Bitmap(stream);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/DotnetPackaging.Exe.Installer/Core/DefaultInstallerPayload.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/DefaultInstallerPayload.cs
@@ -1,4 +1,5 @@
 using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
 using Zafiro.ProgressReporting;
 
 namespace DotnetPackaging.Exe.Installer.Core;
@@ -13,6 +14,9 @@ public sealed class DefaultInstallerPayload : IInstallerPayload
 
     public Task<Result<long>> GetContentSize(CancellationToken ct = default)
         => EnsureLoaded(ct).Map(p => p.ContentSizeBytes);
+
+    public Task<Result<Maybe<IByteSource>>> GetLogo(CancellationToken ct = default)
+        => EnsureLoaded(ct).Map(p => p.Logo);
 
     public Task<Result> CopyContents(string targetDirectory, IObserver<Progress>? progressObserver = null, CancellationToken ct = default)
         => EnsureLoaded(ct).Bind(p => Task.Run(() =>

--- a/src/DotnetPackaging.Exe.Installer/Core/IInstallerPayload.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/IInstallerPayload.cs
@@ -1,4 +1,5 @@
 using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
 using Zafiro.ProgressReporting;
 
 namespace DotnetPackaging.Exe.Installer.Core;
@@ -8,6 +9,8 @@ public interface IInstallerPayload
     Task<Result<InstallerMetadata>> GetMetadata(CancellationToken ct = default);
 
     Task<Result<long>> GetContentSize(CancellationToken ct = default);
+
+    Task<Result<Maybe<IByteSource>>> GetLogo(CancellationToken ct = default);
 
     Task<Result> CopyContents(
         string targetDirectory,

--- a/src/DotnetPackaging.Exe.Installer/Core/InstallerMetadata.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/InstallerMetadata.cs
@@ -6,4 +6,5 @@ public sealed record InstallerMetadata(
     string Version,
     string Vendor,
     string? Description = null,
-    string? ExecutableName = null);
+    string? ExecutableName = null,
+    bool HasLogo = false);

--- a/src/DotnetPackaging.Exe.Installer/Core/MetadataFilePayload.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/MetadataFilePayload.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
 using Zafiro.ProgressReporting;
 
 namespace DotnetPackaging.Exe.Installer.Core;
@@ -52,6 +53,11 @@ internal sealed class MetadataFilePayload : IInstallerPayload
     public Task<Result<long>> GetContentSize(CancellationToken ct = default)
     {
         return Task.FromResult(Result.Failure<long>("Disk-only payload does not provide installation content."));
+    }
+
+    public Task<Result<Maybe<IByteSource>>> GetLogo(CancellationToken ct = default)
+    {
+        return Task.FromResult(Result.Success(Maybe<IByteSource>.None));
     }
 
     public Task<Result> CopyContents(string targetDirectory, IObserver<Progress>? progressObserver = null, CancellationToken ct = default)

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/IWelcomeViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/IWelcomeViewModel.cs
@@ -1,7 +1,10 @@
 using System.Reactive;
+using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
+using Reactive.Bindings;
 using ReactiveUI;
+using Zafiro.DivineBytes;
 
 namespace DotnetPackaging.Exe.Installer.Installation.Wizard.Welcome;
 
@@ -9,4 +12,6 @@ public interface IWelcomeViewModel
 {
     Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
     ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+    ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+    ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
 }

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeView.axaml
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeView.axaml
@@ -13,11 +13,17 @@
     <Interaction.Behaviors>
         <LoadedTrigger>
             <InvokeCommandAction Command="{Binding LoadMetadata}" />
+            <InvokeCommandAction Command="{Binding LoadLogo}" />
         </LoadedTrigger>
     </Interaction.Behaviors>
 
     <Loading IsLoading="{Binding LoadMetadata.IsExecuting^}">
         <DockPanel VerticalSpacing="12">
+            <Image DockPanel.Dock="Right"
+                   Width="96"
+                   Height="96"
+                   Source="{Binding Logo}"
+                   Stretch="Uniform" />
             <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Text="{Binding Metadata.Value.ApplicationName, StringFormat='Welcome to the {0} installation wizard'}" FontSize="20" FontWeight="Bold" />
             <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Right" Text="{Binding Metadata.Value.Version, StringFormat='Version {0}'}" />
             <TextBlock DockPanel.Dock="Top" Text="{Binding Metadata.Value.ApplicationName, StringFormat='This wizard will help you install {0} on this system'}" />

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModel.cs
@@ -1,10 +1,15 @@
-﻿using System.Reactive;
+using System.Reactive;
+using System.Reactive.Linq;
+using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 using Zafiro.CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
 using Zafiro.UI;
 
 namespace DotnetPackaging.Exe.Installer.Installation.Wizard.Welcome;
@@ -17,13 +22,24 @@ public sealed class WelcomeViewModel : ReactiveValidationObject, IWelcomeViewMod
     {
         this.payload = payload;
         LoadMetadata = ReactiveCommand.CreateFromTask(() => this.payload.GetMetadata());
-        Metadata = new Reactive.Bindings.ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
+        Metadata = new ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
         this.ValidationRule(model => model.Metadata.Value, m => m is not null, "Metadata is required");
+
+        LoadLogo = ReactiveCommand.CreateFromTask(() => payload.GetLogo());
+
+        Logo = LoadLogo
+            .Successes()
+            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IBitmap?)null))
+            .ToReadOnlyReactivePropertySlim();
     }
 
-    public Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
+    public ReactiveProperty<InstallerMetadata?> Metadata { get; }
 
     public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+
+    public ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+
+    public ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
 
     public IObservable<bool> IsValid => this.IsValid();
 }

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModelMock.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModelMock.cs
@@ -1,22 +1,48 @@
+using System;
 using System.Reactive;
+using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 using ReactiveUI;
+using Zafiro.DivineBytes;
 
 namespace DotnetPackaging.Exe.Installer.Installation.Wizard.Welcome;
 
 public class WelcomeViewModelMock : IWelcomeViewModel
 {
+    private static readonly byte[] SampleLogo = Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAoMBgNkHFN0AAAAASUVORK5CYII=");
+
     public WelcomeViewModelMock()
     {
-        Metadata = new Reactive.Bindings.ReactiveProperty<InstallerMetadata>(new InstallerMetadata(
+        Metadata = new ReactiveProperty<InstallerMetadata>(new InstallerMetadata(
             "com.example.app",
             "Example App",
             "1.0.0",
-            "Example, Inc.", Description: "This is an example app. It does nothing. It's just a demo."));
+            "Example, Inc.",
+            Description: "This is an example app. It does nothing. It's just a demo.",
+            HasLogo: true));
+
+        LoadLogo = ReactiveCommand.Create(() => Result.Success(Maybe<IByteSource>.From(ByteSource.FromBytes(SampleLogo))));
+
+        Logo = LoadLogo
+            .Successes()
+            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IBitmap?)null))
+            .ToReadOnlyReactivePropertySlim();
     }
 
-    public Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
+    public ReactiveProperty<InstallerMetadata?> Metadata { get; }
 
-    public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+    public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; } = ReactiveCommand.Create(() => Result.Success(new InstallerMetadata(
+        "com.example.app",
+        "Example App",
+        "1.0.0",
+        "Example, Inc.",
+        Description: "This is an example app. It does nothing. It's just a demo.",
+        HasLogo: true)));
+
+    public ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+
+    public ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
 }

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeView.axaml
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeView.axaml
@@ -9,11 +9,17 @@
     <Interaction.Behaviors>
         <LoadedTrigger>
             <InvokeCommandAction Command="{Binding LoadMetadata}" />
+            <InvokeCommandAction Command="{Binding LoadLogo}" />
         </LoadedTrigger>
     </Interaction.Behaviors>
 
     <Loading IsLoading="{Binding LoadMetadata.IsExecuting^}">
         <DockPanel VerticalSpacing="12">
+            <Image DockPanel.Dock="Right"
+                   Width="96"
+                   Height="96"
+                   Source="{Binding Logo}"
+                   Stretch="Uniform" />
             <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Text="{Binding Metadata.Value.ApplicationName, StringFormat='Welcome to the {0} uninstallation wizard'}" FontSize="20" FontWeight="Bold" />
             <TextBlock DockPanel.Dock="Bottom" HorizontalAlignment="Right" Text="{Binding Metadata.Value.Version, StringFormat='Version {0}'}" />
             <TextBlock DockPanel.Dock="Top" Text="{Binding Metadata.Value.ApplicationName, StringFormat='This wizard will help you remove {0} from this system'}" />

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeViewModel.cs
@@ -1,10 +1,15 @@
 using System.Reactive;
+using System.Reactive.Linq;
+using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
+using Reactive.Bindings;
+using Reactive.Bindings.Extensions;
 using ReactiveUI;
 using ReactiveUI.Validation.Extensions;
 using ReactiveUI.Validation.Helpers;
 using Zafiro.CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
 using Zafiro.UI;
 
 namespace DotnetPackaging.Exe.Installer.Uninstallation.Wizard.Welcome;
@@ -17,13 +22,24 @@ public sealed class UninstallWelcomeViewModel : ReactiveValidationObject, IValid
     {
         this.payload = payload;
         LoadMetadata = ReactiveCommand.CreateFromTask(() => this.payload.GetMetadata());
-        Metadata = new Reactive.Bindings.ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
+        Metadata = new ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
         this.ValidationRule(model => model.Metadata.Value, m => m is not null, "Metadata is required");
+
+        LoadLogo = ReactiveCommand.CreateFromTask(() => payload.GetLogo());
+
+        Logo = LoadLogo
+            .Successes()
+            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IBitmap?)null))
+            .ToReadOnlyReactivePropertySlim();
     }
 
-    public Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
+    public ReactiveProperty<InstallerMetadata?> Metadata { get; }
 
     public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+
+    public ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+
+    public ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
 
     public IObservable<bool> IsValid => this.IsValid();
 }

--- a/src/DotnetPackaging.Exe.Tests/SimpleExePackerTests.cs
+++ b/src/DotnetPackaging.Exe.Tests/SimpleExePackerTests.cs
@@ -29,7 +29,7 @@ public class SimpleExePackerTests
         var metadata = new InstallerMetadata("com.test.strip", "Test Strip", "1.0.0", "Test Vendor", "Desc", "App.exe");
 
         // Act 1: Build Installer (Stub + Payload)
-        await SimpleExePacker.Build(stubPath, publishDir.FullName, metadata, outputInstaller);
+        await SimpleExePacker.Build(stubPath, publishDir.FullName, metadata, Maybe<byte[]>.None, outputInstaller);
 
         // Act 2: Strip Payload to create Uninstaller
         using (var src = File.OpenRead(outputInstaller))
@@ -94,7 +94,7 @@ public class SimpleExePackerTests
         var metadata = new InstallerMetadata("com.test.extract", "Test Extract", "1.0.0", "Test Vendor", "Desc", "App.exe");
 
         // Act 1: Build Installer
-        await SimpleExePacker.Build(originalStubPath, publishDir.FullName, metadata, outputInstaller);
+        await SimpleExePacker.Build(originalStubPath, publishDir.FullName, metadata, Maybe<byte[]>.None, outputInstaller);
 
         // Act 2: Try to extract payload using the SAME logic as the installer uses
         // We need to invoke PayloadExtractor logic. Since it's internal in another assembly, we'll duplicate the logic or use reflection?
@@ -152,7 +152,7 @@ public class SimpleExePackerTests
         File.WriteAllText(Path.Combine(publishDir.FullName, "App.exe"), "Dummy App");
 
         var metadata = new InstallerMetadata("com.test.boot", "Test Boot", "1.0.0", "Test Vendor", "Desc", "App.exe");
-        await SimpleExePacker.Build(ResolveStubPath(), publishDir.FullName, metadata, outputInstaller);
+        await SimpleExePacker.Build(ResolveStubPath(), publishDir.FullName, metadata, Maybe<byte[]>.None, outputInstaller);
 
         var psi = new ProcessStartInfo(outputInstaller)
         {
@@ -195,7 +195,7 @@ public class SimpleExePackerTests
         File.WriteAllText(Path.Combine(publishDir.FullName, "App.exe"), "Dummy App");
 
         var metadata = new InstallerMetadata("com.test.uninstall", "Test Uninstall", "1.0.0", "Test Vendor", "Desc", "App.exe");
-        await SimpleExePacker.Build(ResolveStubPath(), publishDir.FullName, metadata, outputInstaller);
+        await SimpleExePacker.Build(ResolveStubPath(), publishDir.FullName, metadata, Maybe<byte[]>.None, outputInstaller);
 
         PayloadExtractor.GetAppendedPayloadStart(outputInstaller).HasValue.Should().BeTrue();
 
@@ -252,7 +252,7 @@ public class SimpleExePackerTests
         File.WriteAllText(Path.Combine(publishDir.FullName, "App.exe"), "Dummy App");
 
         var metadata = new InstallerMetadata("com.test.dispatcher", "Test Dispatcher", "1.0.0", "Test Vendor", "Desc", "App.exe");
-        await SimpleExePacker.Build(ResolveStubPath(), publishDir.FullName, metadata, outputInstaller);
+        await SimpleExePacker.Build(ResolveStubPath(), publishDir.FullName, metadata, Maybe<byte[]>.None, outputInstaller);
 
         var psi = new ProcessStartInfo(outputInstaller)
         {

--- a/src/DotnetPackaging.Exe/InstallerMetadata.cs
+++ b/src/DotnetPackaging.Exe/InstallerMetadata.cs
@@ -6,4 +6,5 @@ public sealed record InstallerMetadata(
     string Version,
     string Vendor,
     string? Description = null,
-    string? ExecutableName = null);
+    string? ExecutableName = null,
+    bool HasLogo = false);


### PR DESCRIPTION
## Summary
- embed the optional setup logo as a binary payload entry instead of metadata base64 so large images travel efficiently
- expose the payload logo through installer/uninstaller view models and display it from the extracted bytes
- keep installer metadata compatible by only flagging the presence of branding in a boolean field

## Testing
- dotnet test *(fails: solution file error MSB5004 – duplicate DotnetPackaging.Exe.Tests project entries)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204762ea64832f81dbcb7775455a39)