### PR TITLE
Fix installer logo handling and update tests

### DIFF
--- a/src/DotnetPackaging.Exe.Installer/Core/BrandingLogoFactory.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/BrandingLogoFactory.cs
@@ -1,3 +1,4 @@
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Zafiro.DivineBytes;
 
@@ -5,7 +6,7 @@ namespace DotnetPackaging.Exe.Installer.Core;
 
 internal static class BrandingLogoFactory
 {
-    public static IBitmap? FromBytes(IByteSource? bytes)
+    public static IImage? FromBytes(IByteSource? bytes)
     {
         if (bytes is null)
         {

--- a/src/DotnetPackaging.Exe.Installer/Core/MetadataFilePayload.cs
+++ b/src/DotnetPackaging.Exe.Installer/Core/MetadataFilePayload.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using CSharpFunctionalExtensions;
 using Zafiro.DivineBytes;
 using Zafiro.ProgressReporting;
+using Path = System.IO.Path;
 
 namespace DotnetPackaging.Exe.Installer.Core;
 

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/IWelcomeViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/IWelcomeViewModel.cs
@@ -1,5 +1,5 @@
 using System.Reactive;
-using Avalonia.Media.Imaging;
+using Avalonia.Media;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
 using Reactive.Bindings;
@@ -11,7 +11,7 @@ namespace DotnetPackaging.Exe.Installer.Installation.Wizard.Welcome;
 public interface IWelcomeViewModel
 {
     Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
-    ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
-    ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
-    ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
+    ReactiveUI.ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+    ReactiveUI.ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+    ReadOnlyReactivePropertySlim<IImage?> Logo { get; }
 }

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModel.cs
@@ -1,5 +1,6 @@
 using System.Reactive;
 using System.Reactive.Linq;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
@@ -21,25 +22,25 @@ public sealed class WelcomeViewModel : ReactiveValidationObject, IWelcomeViewMod
     public WelcomeViewModel(IInstallerPayload payload)
     {
         this.payload = payload;
-        LoadMetadata = ReactiveCommand.CreateFromTask(() => this.payload.GetMetadata());
-        Metadata = new ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
+        LoadMetadata = ReactiveUI.ReactiveCommand.CreateFromTask(() => this.payload.GetMetadata());
+        Metadata = new Reactive.Bindings.ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
         this.ValidationRule(model => model.Metadata.Value, m => m is not null, "Metadata is required");
 
-        LoadLogo = ReactiveCommand.CreateFromTask(() => payload.GetLogo());
+        LoadLogo = ReactiveUI.ReactiveCommand.CreateFromTask(() => payload.GetLogo());
 
         Logo = LoadLogo
             .Successes()
-            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IBitmap?)null))
+            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IImage?)null))
             .ToReadOnlyReactivePropertySlim();
     }
 
-    public ReactiveProperty<InstallerMetadata?> Metadata { get; }
+    public Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
 
-    public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+    public ReactiveUI.ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
 
-    public ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+    public ReactiveUI.ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
 
-    public ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
+    public ReadOnlyReactivePropertySlim<IImage?> Logo { get; }
 
     public IObservable<bool> IsValid => this.IsValid();
 }

--- a/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModelMock.cs
+++ b/src/DotnetPackaging.Exe.Installer/Installation/Wizard/Welcome/WelcomeViewModelMock.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Reactive;
+using System.Reactive.Linq;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
 using ReactiveUI;
+using Zafiro.CSharpFunctionalExtensions;
 using Zafiro.DivineBytes;
 
 namespace DotnetPackaging.Exe.Installer.Installation.Wizard.Welcome;
@@ -16,7 +19,7 @@ public class WelcomeViewModelMock : IWelcomeViewModel
 
     public WelcomeViewModelMock()
     {
-        Metadata = new ReactiveProperty<InstallerMetadata>(new InstallerMetadata(
+        Metadata = new Reactive.Bindings.ReactiveProperty<InstallerMetadata?>(new InstallerMetadata(
             "com.example.app",
             "Example App",
             "1.0.0",
@@ -24,17 +27,17 @@ public class WelcomeViewModelMock : IWelcomeViewModel
             Description: "This is an example app. It does nothing. It's just a demo.",
             HasLogo: true));
 
-        LoadLogo = ReactiveCommand.Create(() => Result.Success(Maybe<IByteSource>.From(ByteSource.FromBytes(SampleLogo))));
+        LoadLogo = ReactiveUI.ReactiveCommand.Create(() => Result.Success(Maybe<IByteSource>.From(ByteSource.FromBytes(SampleLogo))));
 
         Logo = LoadLogo
             .Successes()
-            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IBitmap?)null))
+            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IImage?)null))
             .ToReadOnlyReactivePropertySlim();
     }
 
-    public ReactiveProperty<InstallerMetadata?> Metadata { get; }
+    public Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
 
-    public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; } = ReactiveCommand.Create(() => Result.Success(new InstallerMetadata(
+    public ReactiveUI.ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; } = ReactiveUI.ReactiveCommand.Create(() => Result.Success(new InstallerMetadata(
         "com.example.app",
         "Example App",
         "1.0.0",
@@ -42,7 +45,7 @@ public class WelcomeViewModelMock : IWelcomeViewModel
         Description: "This is an example app. It does nothing. It's just a demo.",
         HasLogo: true)));
 
-    public ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+    public ReactiveUI.ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
 
-    public ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
+    public ReadOnlyReactivePropertySlim<IImage?> Logo { get; }
 }

--- a/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeViewModel.cs
+++ b/src/DotnetPackaging.Exe.Installer/Uninstallation/Wizard/Welcome/UninstallWelcomeViewModel.cs
@@ -1,5 +1,6 @@
 using System.Reactive;
 using System.Reactive.Linq;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Installer.Core;
@@ -21,25 +22,25 @@ public sealed class UninstallWelcomeViewModel : ReactiveValidationObject, IValid
     public UninstallWelcomeViewModel(IInstallerPayload payload)
     {
         this.payload = payload;
-        LoadMetadata = ReactiveCommand.CreateFromTask(() => this.payload.GetMetadata());
-        Metadata = new ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
+        LoadMetadata = ReactiveUI.ReactiveCommand.CreateFromTask(() => this.payload.GetMetadata());
+        Metadata = new Reactive.Bindings.ReactiveProperty<InstallerMetadata?>(LoadMetadata.Successes());
         this.ValidationRule(model => model.Metadata.Value, m => m is not null, "Metadata is required");
 
-        LoadLogo = ReactiveCommand.CreateFromTask(() => payload.GetLogo());
+        LoadLogo = ReactiveUI.ReactiveCommand.CreateFromTask(() => payload.GetLogo());
 
         Logo = LoadLogo
             .Successes()
-            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IBitmap?)null))
+            .Select(logoBytes => logoBytes.Match(BrandingLogoFactory.FromBytes, () => (IImage?)null))
             .ToReadOnlyReactivePropertySlim();
     }
 
-    public ReactiveProperty<InstallerMetadata?> Metadata { get; }
+    public Reactive.Bindings.ReactiveProperty<InstallerMetadata?> Metadata { get; }
 
-    public ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
+    public ReactiveUI.ReactiveCommand<Unit, Result<InstallerMetadata>> LoadMetadata { get; }
 
-    public ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
+    public ReactiveUI.ReactiveCommand<Unit, Result<Maybe<IByteSource>>> LoadLogo { get; }
 
-    public ReadOnlyReactivePropertySlim<IBitmap?> Logo { get; }
+    public ReadOnlyReactivePropertySlim<IImage?> Logo { get; }
 
     public IObservable<bool> IsValid => this.IsValid();
 }

--- a/src/DotnetPackaging.Exe/ExePackagingService.cs
+++ b/src/DotnetPackaging.Exe/ExePackagingService.cs
@@ -579,12 +579,14 @@ public sealed class ExePackagingService
                 await src.CopyToAsync(dst);
             }
 
-            foreach (var bytes in logoBytes)
-            {
-                var logoEntry = zip.CreateEntry(BrandingLogoEntry, CompressionLevel.NoCompression);
-                await using var logoStream = logoEntry.Open();
-                await logoStream.WriteAsync(bytes, 0, bytes.Length);
-            }
+            await logoBytes.Match(
+                async bytes =>
+                {
+                    var logoEntry = zip.CreateEntry(BrandingLogoEntry, CompressionLevel.NoCompression);
+                    await using var logoStream = logoEntry.Open();
+                    await logoStream.WriteAsync(bytes, 0, bytes.Length);
+                },
+                () => Task.CompletedTask);
 
             return Result.Success(zipPath);
         }

--- a/src/DotnetPackaging.Exe/SimpleExePacker.cs
+++ b/src/DotnetPackaging.Exe/SimpleExePacker.cs
@@ -88,11 +88,13 @@ public static class SimpleExePacker
             await src.CopyToAsync(dst);
         }
 
-        foreach (var bytes in logoBytes)
-        {
-            var logoEntry = zip.CreateEntry(BrandingLogoEntry, CompressionLevel.NoCompression);
-            await using var stream = logoEntry.Open();
-            await stream.WriteAsync(bytes, 0, bytes.Length);
-        }
+        await logoBytes.Match(
+            async bytes =>
+            {
+                var logoEntry = zip.CreateEntry(BrandingLogoEntry, CompressionLevel.NoCompression);
+                await using var stream = logoEntry.Open();
+                await stream.WriteAsync(bytes, 0, bytes.Length);
+            },
+            () => Task.CompletedTask);
     }
 }

--- a/test/DotnetPackaging.Exe.Tests/ExeSfxEndToEndTests.cs
+++ b/test/DotnetPackaging.Exe.Tests/ExeSfxEndToEndTests.cs
@@ -27,7 +27,7 @@ public class ExeSfxEndToEndTests
 
         // Act: build the SFX installer from the project
         var service = new ExePackagingService();
-        var result = await service.BuildFromProject(new FileInfo(projectPath), "win-x64", true, "Release", true, false, new FileInfo(outputExe), new Options(), vendor: null, stubFile: null);
+        var result = await service.BuildFromProject(new FileInfo(projectPath), "win-x64", true, "Release", true, false, new FileInfo(outputExe), new Options(), vendor: null, stubFile: null, setupLogo: null);
         result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : string.Empty);
 
         // Run the produced installer with the env hook to dump metadata and exit


### PR DESCRIPTION
## Summary
- use Avalonia IImage for installer logos and update view models
- handle optional logo byte sources with Maybe.Match instead of foreach
- refresh metadata payload path handling and adjust EXE E2E test signature

## Testing
- dotnet build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69205f8dea0c832fb14ab1bc2338ae7c)