### PR TITLE
Fix uninstaller payload resolution and logo handling

### DIFF
--- a/src/DotnetPackaging.Exe.Installer/Flows/Installation/Wizard/InstallWizard.cs
+++ b/src/DotnetPackaging.Exe.Installer/Flows/Installation/Wizard/InstallWizard.cs
@@ -52,7 +52,7 @@ public class InstallWizard
     {
         return Task.Run(() =>
             PayloadExtractor.CopyContentTo(payload, installDir, progressObserver)
-                .Bind(() => Core.Installer.Install(installDir, payload.Metadata, payload.ContentSizeBytes))
+                .Bind(() => Core.Installer.Install(installDir, payload.Metadata, payload.ContentSizeBytes, payload.Logo))
                 .Map(exePath => new InstallationResult(payload.Metadata, installDir, exePath)));
     }
     

--- a/src/DotnetPackaging.Exe.Installer/Flows/Uninstallation/Wizard/Steps/UninstallView.axaml
+++ b/src/DotnetPackaging.Exe.Installer/Flows/Uninstallation/Wizard/Steps/UninstallView.axaml
@@ -17,6 +17,7 @@
 
         <TextBlock TextWrapping="Wrap"
                    VerticalAlignment="Center"
+                   IsVisible="{Binding InstallationMissing}"
                    TextTrimming="{x:Static TextTrimming.LeadingCharacterEllipsis}"
                    Text="{Binding ErrorMessage, StringFormat='Unable to locate an installation for this package: {0}'}" />
     </StackPanel>


### PR DESCRIPTION
## Summary
- store installer logo assets alongside metadata so the uninstaller can display branding when running from the install folder
- surface disk-based metadata and logo payloads for uninstallers and hide the missing-installation message when a record exists
- add coverage ensuring metadata payloads expose persisted logos

## Testing
- dotnet test (fails: DotnetPackaging.Msix.Tests missing TestFiles/ValidExe/Expected.msix)
- dotnet test test/DotnetPackaging.Exe.Tests/DotnetPackaging.Exe.Tests.csproj -p:DisableParallelization=true

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921d1a4e720832f9c415189eddefe34)