### PR TITLE
Fix Path reference in SimpleExePackerTests

### DIFF
--- a/src/DotnetPackaging.Exe.Tests/SimpleExePackerTests.cs
+++ b/src/DotnetPackaging.Exe.Tests/SimpleExePackerTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
+using Path = System.IO.Path;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe;
 using DotnetPackaging.Exe.Installer.Core;


### PR DESCRIPTION
## Summary
- resolve Path type ambiguity in SimpleExePackerTests by aliasing System.IO.Path

## Testing
- dotnet build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692232666048832fa1a4d712cc9cae28)