### PR TITLE
Refactor EXE packaging to use byte sources

### DIFF
--- a/src/DotnetPackaging.Exe/PayloadAppender.cs
+++ b/src/DotnetPackaging.Exe/PayloadAppender.cs
@@ -1,20 +1,32 @@
 using System.Text;
+using Zafiro.DivineBytes;
 
 namespace DotnetPackaging.Exe;
 
 public static class PayloadAppender
 {
-    public static void AppendPayload(string signedStubPath, string payloadZipPath, string outputPath)
+    public static IByteSource AppendPayload(IByteSource signedStub, IByteSource payload)
     {
-        var stubBytes = File.ReadAllBytes(signedStubPath);
-        var payloadBytes = File.ReadAllBytes(payloadZipPath);
-        var lengthBytes = BitConverter.GetBytes((long)payloadBytes.Length);
-        var magicBytes = Encoding.ASCII.GetBytes("DPACKEXE1");
+        return ByteSource.FromAsyncStreamFactory(async () =>
+        {
+            var stubStream = signedStub.ToStreamSeekable();
+            var payloadStream = payload.ToStreamSeekable();
+            var output = new MemoryStream();
 
-        using var output = File.Create(outputPath);
-        output.Write(stubBytes);
-        output.Write(payloadBytes);
-        output.Write(lengthBytes);
-        output.Write(magicBytes);
+            await using (stubStream)
+            await using (payloadStream)
+            {
+                await stubStream.CopyToAsync(output);
+                await payloadStream.CopyToAsync(output);
+
+                var lengthBytes = BitConverter.GetBytes(payloadStream.Length);
+                var magicBytes = Encoding.ASCII.GetBytes("DPACKEXE1");
+
+                await output.WriteAsync(lengthBytes, 0, lengthBytes.Length);
+                await output.WriteAsync(magicBytes, 0, magicBytes.Length);
+                output.Position = 0;
+                return output;
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary
- refactor payload appending to work on IByteSource without intermediate filesystem writes
- build installer and uninstaller payloads from containers and metadata rather than temporary directories
- update build script to consume the byte-based appender

## Testing
- dotnet test *(fails: .NET SDK 8.0.416 does not support targeting .NET 9.0 in some test projects)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922510bb1c8832f95222338235dd1c8)