### PR TITLE
Keep deb ar entries streaming tar content

### DIFF
--- a/src/DotnetPackaging.Deb/Archives/Ar/ArFile.cs
+++ b/src/DotnetPackaging.Deb/Archives/Ar/ArFile.cs
@@ -1,11 +1,12 @@
 using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
 using Zafiro.DivineBytes.Unix;
 
 namespace DotnetPackaging.Deb.Archives.Ar;
 
 public record ArFile(params ArEntry[] Entries);
 
-public record ArEntry(string Name, byte[] Content, ArEntryProperties Properties);
+public record ArEntry(string Name, IByteSource Content, long Length, ArEntryProperties Properties);
 
 public record ArEntryProperties
 {

--- a/src/DotnetPackaging.Deb/Archives/Deb/DebMixin.cs
+++ b/src/DotnetPackaging.Deb/Archives/Deb/DebMixin.cs
@@ -22,23 +22,24 @@ public static class DebMixin
     {
         var dataTarFile = new TarFile(debFile.Entries);
         var properties = DefaultProperties(debFile.Metadata.ModificationTime);
-        var content = dataTarFile.ToByteSource().Array();
-        return new ArEntry("data.tar", content, properties);
+        var content = dataTarFile.ToByteSource();
+        return new ArEntry("data.tar", content, dataTarFile.Size(), properties);
     }
 
     private static ArEntry Signature(DebFile debFile)
     {
         var properties = DefaultProperties(debFile.Metadata.ModificationTime);
         var signature = "2.0\n";
-        return new ArEntry("debian-binary", Encoding.ASCII.GetBytes(signature), properties);
+        var signatureBytes = Encoding.ASCII.GetBytes(signature);
+        return new ArEntry("debian-binary", ByteSource.FromBytes(signatureBytes), signatureBytes.Length, properties);
     }
 
     private static ArEntry ControlTar(DebFile debFile)
     {
         var properties = DefaultProperties(debFile.Metadata.ModificationTime);
         var controlTarFile = ControlTarFile(debFile);
-        var content = controlTarFile.ToByteSource().Array();
-        return new ArEntry("control.tar", content, properties);
+        var content = controlTarFile.ToByteSource();
+        return new ArEntry("control.tar", content, controlTarFile.Size(), properties);
     }
 
     private static TarFile ControlTarFile(DebFile deb)


### PR DESCRIPTION
## Summary
- change ar entries to carry byte sources and lengths so tar payloads stream instead of being materialized into byte arrays
- stream ar serialization from byte observables while keeping correct ar headers and padding
- add tar size helper to avoid duplicating tar archives in memory when building deb packages

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692442aa8ccc832fb68af2b0064c4e31)