### PR TITLE
feat: infer IsTerminal from project OutputType in from-project

### DIFF
--- a/src/DotnetPackaging.AppImage/AppImagePackager.cs
+++ b/src/DotnetPackaging.AppImage/AppImagePackager.cs
@@ -46,7 +46,7 @@ public sealed class AppImagePackager
                     container,
                     tuple.arch,
                     tuple.exec,
-                    setup.IsTerminal,
+                    setup.IsTerminal.GetValueOrDefault(false),
                     Maybe<string>.None,
                     log);
 
@@ -77,7 +77,7 @@ public sealed class AppImagePackager
             Homepage = packageMetadata.Homepage.Map(u => u.ToString()),
             ProjectLicense = packageMetadata.License,
             Keywords = packageMetadata.Keywords,
-            IsTerminal = setup.IsTerminal,
+            IsTerminal = setup.IsTerminal.GetValueOrDefault(false),
             Categories = packageMetadata.Categories.HasValue
                 ? Maybe<IEnumerable<string>>.From(GetCategoryStrings(packageMetadata.Categories.Value))
                 : Maybe<IEnumerable<string>>.None

--- a/src/DotnetPackaging.Deb/Builder/FromContainer.cs
+++ b/src/DotnetPackaging.Deb/Builder/FromContainer.cs
@@ -37,7 +37,7 @@ internal class FromContainer
 
         var architecture = architectureResult.Value;
         logger.Information("Architecture resolved to {Arch}", architecture);
-        var metadata = await BuildUtils.CreateMetadata(setup, root, architecture, executable, setup.IsTerminal, containerName, logger);
+        var metadata = await BuildUtils.CreateMetadata(setup, root, architecture, executable, setup.IsTerminal.GetValueOrDefault(false), containerName, logger);
         var entries = TarEntryBuilder.From(root, metadata, executable).ToArray();
 
         return Result.Success(new Archives.Deb.DebFile(metadata, entries));

--- a/src/DotnetPackaging.Deb/DebPackager.cs
+++ b/src/DotnetPackaging.Deb/DebPackager.cs
@@ -39,7 +39,7 @@ public sealed class DebPackager
                     container,
                     tuple.arch,
                     tuple.exec,
-                    setup.IsTerminal,
+                    setup.IsTerminal.GetValueOrDefault(false),
                     Maybe<string>.None,
                     log);
 

--- a/src/DotnetPackaging.Rpm/Builder/FromContainer.cs
+++ b/src/DotnetPackaging.Rpm/Builder/FromContainer.cs
@@ -38,7 +38,7 @@ internal class FromContainer
         var architecture = architectureResult.Value;
         logger.Information("Architecture resolved to {Arch}", architecture);
 
-        var metadata = await BuildUtils.CreateMetadata(setup, root, architecture, executable, setup.IsTerminal, containerName, logger);
+        var metadata = await BuildUtils.CreateMetadata(setup, root, architecture, executable, setup.IsTerminal.GetValueOrDefault(false), containerName, logger);
         var plan = RpmLayoutBuilder.Build(root, metadata, executable);
 
         return await RpmPackager.CreatePackage(metadata, plan);

--- a/src/DotnetPackaging.Rpm/RpmPackager.cs
+++ b/src/DotnetPackaging.Rpm/RpmPackager.cs
@@ -38,7 +38,7 @@ public sealed class RpmPackager
                     container,
                     tuple.arch,
                     tuple.exec,
-                    setup.IsTerminal,
+                    setup.IsTerminal.GetValueOrDefault(false),
                     Maybe<string>.None,
                     log);
 

--- a/src/DotnetPackaging/FromDirectoryOptions.cs
+++ b/src/DotnetPackaging/FromDirectoryOptions.cs
@@ -30,7 +30,7 @@ public class FromDirectoryOptions
     public Maybe<string> VcsGit { get; private set; } = Maybe<string>.None;
     public Maybe<long> InstalledSize { get; private set; } = Maybe<long>.None;
     public Maybe<DateTimeOffset> ModificationTime { get; private set; } = Maybe<DateTimeOffset>.None;
-    public bool IsTerminal { get; private set; }
+    public Maybe<bool> IsTerminal { get; private set; } = Maybe<bool>.None;
     public Maybe<ProjectMetadata> ProjectMetadata { get; private set; } = Maybe<ProjectMetadata>.None;
     public Maybe<string> Vendor { get; private set; } = Maybe<string>.None;
     public Maybe<Uri> Url { get; private set; } = Maybe<Uri>.None;
@@ -237,7 +237,7 @@ public class FromDirectoryOptions
 
     public void WithIsTerminal(bool isTerminalValue)
     {
-        IsTerminal = isTerminalValue;
+        IsTerminal = Maybe<bool>.From(isTerminalValue);
     }
 
     public FromDirectoryOptions WithProjectMetadata(ProjectMetadata projectMetadata)

--- a/src/DotnetPackaging/FromDirectoryOptionsExtensions.cs
+++ b/src/DotnetPackaging/FromDirectoryOptionsExtensions.cs
@@ -41,7 +41,7 @@ public static class FromDirectoryOptionsExtensions
         if (source.ProjectMetadata.HasValue) target.WithProjectMetadata(source.ProjectMetadata.Value);
         if (source.Vendor.HasValue) target.WithVendor(source.Vendor.Value);
         if (source.Url.HasValue) target.WithUrl(source.Url.Value);
-        target.WithIsTerminal(source.IsTerminal);
+        if (source.IsTerminal.HasValue) target.WithIsTerminal(source.IsTerminal.Value);
 
         return target;
     }

--- a/src/DotnetPackaging/ProjectMetadata.cs
+++ b/src/DotnetPackaging/ProjectMetadata.cs
@@ -14,13 +14,14 @@ public sealed record ProjectMetadata(
     Maybe<string> PackageProjectUrl,
     Maybe<string> RepositoryUrl,
     Maybe<string> AssemblyName,
-    Maybe<string> AssemblyTitle);
+    Maybe<string> AssemblyTitle,
+    Maybe<string> OutputType);
 
 public static class ProjectMetadataReader
 {
     private static readonly string[] PropertiesToRead = new[]
     {
-        "Product", "Company", "Description", "Authors", "Copyright", "PackageLicenseExpression", "PackageProjectUrl", "RepositoryUrl", "AssemblyName", "AssemblyTitle"
+        "Product", "Company", "Description", "Authors", "Copyright", "PackageLicenseExpression", "PackageProjectUrl", "RepositoryUrl", "AssemblyName", "AssemblyTitle", "OutputType"
     };
 
     public static Result<ProjectMetadata> Read(FileInfo projectFile)
@@ -104,8 +105,9 @@ public static class ProjectMetadataReader
             var repo = values.GetValueOrDefault("RepositoryUrl");
             var assemblyName = values.GetValueOrDefault("AssemblyName");
             var assemblyTitle = values.GetValueOrDefault("AssemblyTitle");
+            var outputType = values.GetValueOrDefault("OutputType");
 
-            return Result.Success(new ProjectMetadata(product, company, description, authors, copyright, license, url, repo, assemblyName, assemblyTitle));
+            return Result.Success(new ProjectMetadata(product, company, description, authors, copyright, license, url, repo, assemblyName, assemblyTitle, outputType));
         }
         catch (Exception ex)
         {
@@ -127,7 +129,8 @@ public static class ProjectMetadataReader
         var repo = ReadProperty(document, "RepositoryUrl");
         var assemblyName = ReadProperty(document, "AssemblyName");
         var assemblyTitle = ReadProperty(document, "AssemblyTitle");
-        return new ProjectMetadata(product, company, description, authors, copyright, license, url, repo, assemblyName, assemblyTitle);
+        var outputType = ReadProperty(document, "OutputType");
+        return new ProjectMetadata(product, company, description, authors, copyright, license, url, repo, assemblyName, assemblyTitle, outputType);
     }
 
     private static Dictionary<string, Maybe<string>> ParseMsbuildOutput(string output, IEnumerable<string> propertyNames)

--- a/src/DotnetPackaging/ProjectMetadataDefaults.cs
+++ b/src/DotnetPackaging/ProjectMetadataDefaults.cs
@@ -54,6 +54,14 @@ public static class ProjectMetadataDefaults
             inferredExecutable.Execute(name => resolved.WithExecutableName(name));
         }
 
+        if (resolved.IsTerminal.HasNoValue)
+        {
+            projectMetadata
+                .Bind(m => m.OutputType)
+                .Execute(outputType => resolved.WithIsTerminal(
+                    string.Equals(outputType, "Exe", StringComparison.OrdinalIgnoreCase)));
+        }
+
         return resolved;
     }
 

--- a/test/DotnetPackaging.E2E.Tests/DotnetPackaging.E2E.Tests.csproj
+++ b/test/DotnetPackaging.E2E.Tests/DotnetPackaging.E2E.Tests.csproj
@@ -19,4 +19,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotnetPackaging.Tool\DotnetPackaging.Tool.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/test/DotnetPackaging.E2E.Tests/PackagingTests.cs
+++ b/test/DotnetPackaging.E2E.Tests/PackagingTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.CommandLine.Parsing;
+using DotnetPackaging.Tool.Commands;
 using FluentAssertions;
 using Xunit;
 using Xunit.Sdk;
@@ -58,6 +60,32 @@ public class PackagingTests : IDisposable
         var output = Path.Combine(temp.Path, "TestApp.exe");
         await ExecutePackagingCommand("exe", output, "--arch x64");
         File.Exists(output).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Deb_command_should_accept_issue_163_arguments_with_summary_and_comment()
+    {
+        var summary = "ServiceMonitor is a lightweight, configuration\u2011driven monitoring tool for webpages";
+        var comment = "ServiceMonitor is a lightweight, configuration\u2011driven monitoring tool for webpages designed for Linux\u2011based systems (including QNAP NAS). It periodically checks a list of URLs and sends SMTP notifications when services become unreachable or return error states. The focus is on robustness, simplicity, and clean extensibility.";
+
+        var command = DebCommand.GetCommand();
+        var args = new[]
+        {
+            "--directory", "./publish/linux-x64",
+            "--output", "./$(AppName)_$(version)_amd64.deb",
+            "--application-name", "$(AppName)",
+            "--summary", summary,
+            "--comment", comment,
+            "--homepage", "https://github.com/saigkill/ServiceMonitor",
+            "--license", "MIT",
+            "--is-terminal", "true",
+            "--appId", "de.saschamanns.ServiceMonitor",
+            "--version", "$(version)"
+        };
+
+        var parseResult = command.Parse(args);
+        parseResult.Errors.Should().BeEmpty();
+        parseResult.UnmatchedTokens.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

When `--is-terminal` is not explicitly passed to the `from-project` subcommand, the tool now automatically infers the value from the project's `OutputType` MSBuild property:

| `OutputType` | `Terminal=` |
|---|---|
| `Exe` | `true` (console app) |
| `WinExe` | `false` (GUI app) |

The explicit `--is-terminal` flag still works as an override.

## Changes

- **`ProjectMetadata.cs`** — Added `OutputType` field to the record and to `PropertiesToRead` (both MSBuild and XML paths)
- **`FromDirectoryOptions.cs`** — Changed `IsTerminal` from `bool` to `Maybe<bool>` to distinguish "not set" from "explicitly false"
- **`FromDirectoryOptionsExtensions.cs`** — `ApplyOverrides` now only copies `IsTerminal` when source has a value
- **`ProjectMetadataDefaults.cs`** — Infers `IsTerminal` from `OutputType` when not explicitly set
- **Packagers** (`DebPackager`, `RpmPackager`, `AppImagePackager`, `FromContainer` for Deb/Rpm) — Resolve `Maybe<bool>` with `.GetValueOrDefault(false)`