### PR TITLE
feat: add systemd service/daemon support to .deb packaging

### DIFF
--- a/src/DotnetPackaging.Deb/Archives/Deb/DebFile.cs
+++ b/src/DotnetPackaging.Deb/Archives/Deb/DebFile.cs
@@ -1,4 +1,5 @@
-﻿using DotnetPackaging.Deb.Archives.Tar;
+﻿using CSharpFunctionalExtensions;
+using DotnetPackaging.Deb.Archives.Tar;
 
 namespace DotnetPackaging.Deb.Archives.Deb;
 
@@ -6,10 +7,17 @@ internal record DebFile
 {
     public PackageMetadata Metadata { get; }
     public TarEntry[] Entries { get; }
+    public MaintainerScripts Scripts { get; }
 
-    public DebFile(PackageMetadata metadata, params TarEntry[] entries)
+    public DebFile(PackageMetadata metadata, TarEntry[] entries, MaintainerScripts? scripts = null)
     {
         Metadata = metadata;
         Entries = entries;
+        Scripts = scripts ?? MaintainerScripts.None;
     }
+}
+
+internal record MaintainerScripts(Maybe<string> PostInst, Maybe<string> PreRm, Maybe<string> PostRm)
+{
+    public static MaintainerScripts None => new(Maybe<string>.None, Maybe<string>.None, Maybe<string>.None);
 }

--- a/src/DotnetPackaging.Deb/Archives/Deb/DebMixin.cs
+++ b/src/DotnetPackaging.Deb/Archives/Deb/DebMixin.cs
@@ -48,6 +48,16 @@ internal static class DebMixin
             LastModification = deb.Metadata.ModificationTime,
         };
 
+        var executableProperties = new TarFileProperties()
+        {
+            Mode = UnixPermissions.Parse("755"),
+            GroupId = 0,
+            GroupName = "root",
+            OwnerId = 0,
+            OwnerUsername = "root",
+            LastModification = deb.Metadata.ModificationTime,
+        };
+
         var dirProperties = new TarDirectoryProperties()
         {
             Mode = UnixPermissions.Parse("755"),
@@ -73,11 +83,26 @@ internal static class DebMixin
 
         var file = ByteSource.FromString(content);
 
-        var entries = new TarEntry[]
+        var entries = new List<TarEntry>
         {
             new DirectoryTarEntry("./", dirProperties),
             new FileTarEntry("./control", file, fileProperties)
         };
+
+        if (deb.Scripts.PostInst.HasValue)
+        {
+            entries.Add(new FileTarEntry("./postinst", ByteSource.FromString(deb.Scripts.PostInst.Value), executableProperties));
+        }
+
+        if (deb.Scripts.PreRm.HasValue)
+        {
+            entries.Add(new FileTarEntry("./prerm", ByteSource.FromString(deb.Scripts.PreRm.Value), executableProperties));
+        }
+
+        if (deb.Scripts.PostRm.HasValue)
+        {
+            entries.Add(new FileTarEntry("./postrm", ByteSource.FromString(deb.Scripts.PostRm.Value), executableProperties));
+        }
 
         // TODO: Add other properties, too
         //Homepage: {deb.ControlMetadata.Homepage}

--- a/src/DotnetPackaging.Deb/Builder/TarEntryBuilder.cs
+++ b/src/DotnetPackaging.Deb/Builder/TarEntryBuilder.cs
@@ -21,11 +21,34 @@ internal static class TarEntryBuilder
 
     private static IEnumerable<FileTarEntry> ImplicitFileEntries(PackageMetadata metadata, string executablePath)
     {
-        return new FileTarEntry[]
+        var isService = metadata.Service.HasValue;
+        var entries = new List<FileTarEntry>();
+
+        if (!isService)
         {
-            new($"./usr/share/applications/{metadata.Package.ToLowerInvariant()}.desktop", ByteSource.FromString(TextTemplates.DesktopFileContents(executablePath, metadata), Encoding.ASCII), Misc.RegularFileProperties()),
-            new($"./usr/bin/{metadata.Package.ToLowerInvariant()}", ByteSource.FromString(TextTemplates.RunScript(executablePath), Encoding.ASCII), Misc.ExecutableFileProperties())
-        }.Concat(GetIconEntries(metadata));
+            entries.Add(new FileTarEntry(
+                $"./usr/share/applications/{metadata.Package.ToLowerInvariant()}.desktop",
+                ByteSource.FromString(TextTemplates.DesktopFileContents(executablePath, metadata), Encoding.ASCII),
+                Misc.RegularFileProperties()));
+        }
+
+        entries.Add(new FileTarEntry(
+            $"./usr/bin/{metadata.Package.ToLowerInvariant()}",
+            ByteSource.FromString(TextTemplates.RunScript(executablePath), Encoding.ASCII),
+            Misc.ExecutableFileProperties()));
+
+        if (isService)
+        {
+            var appDir = $"/opt/{metadata.Package}";
+            var unitContent = TextTemplates.SystemdUnitFile(executablePath, appDir, metadata);
+            entries.Add(new FileTarEntry(
+                $"./lib/systemd/system/{metadata.Package.ToLowerInvariant()}.service",
+                ByteSource.FromString(unitContent, Encoding.ASCII),
+                Misc.RegularFileProperties()));
+        }
+
+        entries.AddRange(GetIconEntries(metadata));
+        return entries;
     }
 
     private static IEnumerable<FileTarEntry> GetIconEntries(PackageMetadata metadata)

--- a/src/DotnetPackaging.Deb/DebPackager.cs
+++ b/src/DotnetPackaging.Deb/DebPackager.cs
@@ -44,8 +44,22 @@ public sealed class DebPackager
                     log);
 
                 var entries = TarEntryBuilder.From(container, packageMetadata, tuple.exec).ToArray();
-                var deb = new Archives.Deb.DebFile(packageMetadata, entries);
+                var scripts = BuildMaintainerScripts(packageMetadata);
+                var deb = new Archives.Deb.DebFile(packageMetadata, entries, scripts);
                 return Result.Success<IByteSource>(DebMixin.ToByteSource(deb));
             });
+    }
+
+    private static MaintainerScripts BuildMaintainerScripts(PackageMetadata metadata)
+    {
+        if (!metadata.Service.HasValue)
+        {
+            return MaintainerScripts.None;
+        }
+
+        return new MaintainerScripts(
+            PostInst: TextTemplates.PostInstScript(metadata.Package),
+            PreRm: TextTemplates.PreRmScript(metadata.Package),
+            PostRm: TextTemplates.PostRmScript(metadata.Package));
     }
 }

--- a/src/DotnetPackaging.Tool/Commands/AppImageCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/AppImageCommand.cs
@@ -23,6 +23,7 @@ public static class AppImageCommand
             CreateAppImage,
             "Create a portable AppImage (.AppImage) from a published directory. Use subcommands for AppDir workflows.",
             null,
+            null,
             "pack-appimage");
 
         AddAppImageSubcommands(command);
@@ -92,47 +93,8 @@ public static class AppImageCommand
 
     private static void AddAppImageSubcommands(Command appImageCommand)
     {
-        var appName = new Option<string>("--application-name") { Description = "Application name", Required = false };
-        appName.Aliases.Add("--productName");
-        appName.Aliases.Add("--appName");
-        var startupWmClass = new Option<string>("--wm-class") { Description = "Startup WM Class", Required = false };
-        var mainCategory = new Option<MainCategory?>("--main-category") { Description = "Main category", Required = false, Arity = ArgumentArity.ZeroOrOne };
-        var additionalCategories = new Option<IEnumerable<AdditionalCategory>>("--additional-categories") { Description = "Additional categories", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var keywords = new Option<IEnumerable<string>>("--keywords") { Description = "Keywords", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var comment = new Option<string>("--comment") { Description = "Comment", Required = false };
-        var version = new Option<string>("--version") { Description = "Version", Required = false };
-        var homePage = new Option<Uri>("--homepage") { Description = "Home page of the application", Required = false };
-        homePage.CustomParser = OptionsBinder.GetUri;
-        var license = new Option<string>("--license") { Description = "License of the application", Required = false };
-        var screenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls") { Description = "Screenshot URLs", Required = false };
-        screenshotUrls.CustomParser = OptionsBinder.GetUris;
-        var summary = new Option<string>("--summary") { Description = "Summary. Short description that should not end in a dot.", Required = false };
-        var appId = new Option<string>("--appId") { Description = "Application Id. Usually a Reverse DNS name like com.SomeCompany.SomeApplication", Required = false };
-        var executableName = new Option<string>("--executable-name") { Description = "Name of your application's executable", Required = false };
-        var isTerminal = new Option<bool>("--is-terminal") { Description = "Indicates whether your application is a terminal application", Required = false };
-        var iconOption = new Option<IIcon?>("--icon")
-        {
-            Required = false,
-            Description = "Path to the application icon"
-        };
-        iconOption.CustomParser = OptionsBinder.GetIcon;
-
-        var binder = new OptionsBinder(
-            appName,
-            startupWmClass,
-            keywords,
-            comment,
-            mainCategory,
-            additionalCategories,
-            iconOption,
-            version,
-            homePage,
-            license,
-            screenshotUrls,
-            summary,
-            appId,
-            executableName,
-            isTerminal);
+        var metadata = new MetadataOptionSet();
+        var binder = metadata.CreateBinder();
 
         // appimage appdir
         var inputDir = new Option<DirectoryInfo>("--directory") { Description = "The input directory (publish output)", Required = true };
@@ -140,59 +102,33 @@ public static class AppImageCommand
         var appDirCmd = new Command("appdir") { Description = "Creates an AppDir from a directory (does not package an .AppImage). For .NET apps, pass the publish directory." };
         appDirCmd.Add(inputDir);
         appDirCmd.Add(outputDir);
-        appDirCmd.Add(appName);
-        appDirCmd.Add(startupWmClass);
-        appDirCmd.Add(mainCategory);
-        appDirCmd.Add(additionalCategories);
-        appDirCmd.Add(keywords);
-        appDirCmd.Add(comment);
-        appDirCmd.Add(version);
-        appDirCmd.Add(homePage);
-        appDirCmd.Add(license);
-        appDirCmd.Add(screenshotUrls);
-        appDirCmd.Add(summary);
-        appDirCmd.Add(appId);
-        appDirCmd.Add(executableName);
-        appDirCmd.Add(isTerminal);
-        appDirCmd.Add(iconOption);
+        metadata.AddTo(appDirCmd);
         appDirCmd.SetAction(async parseResult =>
         {
             var directory = parseResult.GetValue(inputDir)!;
             var output = parseResult.GetValue(outputDir)!;
-            var metadata = binder.Bind(parseResult);
-            await ExecutionWrapper.ExecuteWithLogging("appimage-appdir", output.FullName, logger => CreateAppDir(directory, output, metadata, logger));
+            var opts = binder.Bind(parseResult);
+            await ExecutionWrapper.ExecuteWithLogging("appimage-appdir", output.FullName, logger => CreateAppDir(directory, output, opts, logger));
         });
 
         // appimage from-appdir
         var appDirPath = new Option<DirectoryInfo>("--directory") { Description = "The AppDir directory to package", Required = true };
         var outputFile = new Option<FileInfo>("--output") { Description = "Output .AppImage file", Required = true };
         var execRel = new Option<string>("--executable-relative-path") { Description = "Executable inside the AppDir (relative), e.g., usr/bin/MyApp", Required = false };
+        var fromAppDirMetadata = new MetadataOptionSet();
+        var fromAppDirBinder = fromAppDirMetadata.CreateBinder();
         var fromAppDirCmd = new Command("from-appdir") { Description = "Creates an AppImage from an existing AppDir directory." };
         fromAppDirCmd.Add(appDirPath);
         fromAppDirCmd.Add(outputFile);
         fromAppDirCmd.Add(execRel);
-        fromAppDirCmd.Add(appName);
-        fromAppDirCmd.Add(startupWmClass);
-        fromAppDirCmd.Add(mainCategory);
-        fromAppDirCmd.Add(additionalCategories);
-        fromAppDirCmd.Add(keywords);
-        fromAppDirCmd.Add(comment);
-        fromAppDirCmd.Add(version);
-        fromAppDirCmd.Add(homePage);
-        fromAppDirCmd.Add(license);
-        fromAppDirCmd.Add(screenshotUrls);
-        fromAppDirCmd.Add(summary);
-        fromAppDirCmd.Add(appId);
-        fromAppDirCmd.Add(executableName);
-        fromAppDirCmd.Add(isTerminal);
-        fromAppDirCmd.Add(iconOption);
+        fromAppDirMetadata.AddTo(fromAppDirCmd);
         fromAppDirCmd.SetAction(async parseResult =>
         {
             var directory = parseResult.GetValue(appDirPath)!;
             var output = parseResult.GetValue(outputFile)!;
             var relativeExec = parseResult.GetValue(execRel);
-            var metadata = binder.Bind(parseResult);
-            await ExecutionWrapper.ExecuteWithLogging("appimage-from-appdir", output.FullName, logger => CreateAppImageFromAppDir(directory, output, relativeExec, metadata, logger));
+            var opts = fromAppDirBinder.Bind(parseResult);
+            await ExecutionWrapper.ExecuteWithLogging("appimage-from-appdir", output.FullName, logger => CreateAppImageFromAppDir(directory, output, relativeExec, opts, logger));
         });
 
         appImageCommand.Add(appDirCmd);
@@ -228,96 +164,30 @@ public static class AppImageCommand
 
     private static void AddFromProjectSubcommand(Command appImageCommand)
     {
-        var project = new Option<FileInfo>("--project") { Description = "Path to the .csproj file", Required = true };
-        var arch = new Option<string?>("--arch") { Description = "Target architecture (x64, arm64). Auto-detects from current system if not specified." };
-        var selfContained = new Option<bool>("--self-contained") { Description = "Publish self-contained [Deprecated]" };
-        selfContained.DefaultValueFactory = _ => true;
-        var configuration = new Option<string>("--configuration") { Description = "Build configuration" };
-        configuration.DefaultValueFactory = _ => "Release";
-        var singleFile = new Option<bool>("--single-file") { Description = "Publish single-file" };
-        var trimmed = new Option<bool>("--trimmed") { Description = "Enable trimming" };
-        var output = new Option<FileInfo>("--output") { Description = "Output .AppImage file", Required = true };
-
-        var appName = new Option<string>("--application-name") { Description = "Application name", Required = false };
-        appName.Aliases.Add("--productName");
-        appName.Aliases.Add("--appName");
-        var startupWmClass = new Option<string>("--wm-class") { Description = "Startup WM Class", Required = false };
-        var mainCategory = new Option<MainCategory?>("--main-category") { Description = "Main category", Required = false, Arity = ArgumentArity.ZeroOrOne };
-        var additionalCategories = new Option<IEnumerable<AdditionalCategory>>("--additional-categories") { Description = "Additional categories", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var keywords = new Option<IEnumerable<string>>("--keywords") { Description = "Keywords", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var comment = new Option<string>("--comment") { Description = "Comment", Required = false };
-        var version = new Option<string>("--version") { Description = "Version", Required = false };
-        var homePage = new Option<Uri>("--homepage") { Description = "Home page of the application", Required = false };
-        homePage.CustomParser = OptionsBinder.GetUri;
-        var license = new Option<string>("--license") { Description = "License of the application", Required = false };
-        var screenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls") { Description = "Screenshot URLs", Required = false };
-        screenshotUrls.CustomParser = OptionsBinder.GetUris;
-        var summary = new Option<string>("--summary") { Description = "Summary. Short description that should not end in a dot.", Required = false };
-        var appId = new Option<string>("--appId") { Description = "Application Id. Usually a Reverse DNS name like com.SomeCompany.SomeApplication", Required = false };
-        var executableName = new Option<string>("--executable-name") { Description = "Name of your application's executable", Required = false };
-        var isTerminal = new Option<bool>("--is-terminal") { Description = "Indicates whether your application is a terminal application", Required = false };
-        var iconOption = new Option<IIcon?>("--icon") { Required = false, Description = "Path to the application icon" };
-        iconOption.CustomParser = OptionsBinder.GetIcon;
-
-        var optionsBinder = new OptionsBinder(appName, startupWmClass, keywords, comment, mainCategory, additionalCategories, iconOption, version, homePage, license, screenshotUrls, summary, appId, executableName, isTerminal);
+        var metadata = new MetadataOptionSet();
+        var project = new ProjectOptionSet(".AppImage");
 
         var fromProject = new Command("from-project") { Description = "Publish a .NET project and build an AppImage from the published output." };
-        fromProject.Add(project);
-        fromProject.Add(arch);
-        fromProject.Add(selfContained);
-        fromProject.Add(configuration);
-        fromProject.Add(singleFile);
-        fromProject.Add(trimmed);
-        fromProject.Add(output);
-        fromProject.Add(appName);
-        fromProject.Add(startupWmClass);
-        fromProject.Add(mainCategory);
-        fromProject.Add(additionalCategories);
-        fromProject.Add(keywords);
-        fromProject.Add(comment);
-        fromProject.Add(version);
-        fromProject.Add(homePage);
-        fromProject.Add(license);
-        fromProject.Add(screenshotUrls);
-        fromProject.Add(summary);
-        fromProject.Add(appId);
-        fromProject.Add(executableName);
-        fromProject.Add(isTerminal);
-        fromProject.Add(iconOption);
+        project.AddTo(fromProject);
+        metadata.AddTo(fromProject);
+
+        var binder = metadata.CreateBinder();
 
         fromProject.SetAction(async parseResult =>
         {
-            var prj = parseResult.GetValue(project)!;
-            var sc = parseResult.GetValue(selfContained);
-            var cfg = parseResult.GetValue(configuration)!;
-            var sf = parseResult.GetValue(singleFile);
-            var tr = parseResult.GetValue(trimmed);
-            var outFile = parseResult.GetValue(output)!;
-            var opt = optionsBinder.Bind(parseResult);
-            var archVal = parseResult.GetValue(arch);
+            var prj = parseResult.GetValue(project.Project)!;
+            var cfg = parseResult.GetValue(project.Configuration)!;
+            var sf = parseResult.GetValue(project.SingleFile);
+            var tr = parseResult.GetValue(project.Trimmed);
+            var outFile = parseResult.GetValue(project.Output)!;
+            var opt = binder.Bind(parseResult);
+            var archVal = parseResult.GetValue(project.Arch);
             var logger = Log.ForContext("command", "appimage-from-project");
 
-            // Auto-detect architecture if not specified
             if (archVal == null)
             {
-                archVal = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture switch
-                {
-                    System.Runtime.InteropServices.Architecture.X64 => "x64",
-                    System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
-                    System.Runtime.InteropServices.Architecture.Arm => "arm",
-                    System.Runtime.InteropServices.Architecture.X86 => "x86",
-                    _ => null
-                };
-
-                if (archVal != null)
-                {
-                    logger.Information("Architecture not specified, auto-detected: {Arch}", archVal);
-                }
-                else
-                {
-                    logger.Error("Unable to auto-detect architecture. Please specify --arch explicitly (e.g., --arch x64)");
-                    return;
-                }
+                archVal = ProjectOptionSet.AutoDetectArch(logger);
+                if (archVal == null) return;
             }
 
             var result = await new AppImage.AppImagePackager().PackProject(

--- a/src/DotnetPackaging.Tool/Commands/CommandFactory.cs
+++ b/src/DotnetPackaging.Tool/Commands/CommandFactory.cs
@@ -12,6 +12,7 @@ public static class CommandFactory
         Func<DirectoryInfo, FileInfo, Options, ILogger, Task> handler,
         string? description = null,
         Option<bool>? defaultLayoutOption = null,
+        Action<Options, ParseResult>? optionsPostProcessor = null,
         params string[] aliases)
     {
         var buildDir = new Option<DirectoryInfo>("--directory")
@@ -24,91 +25,8 @@ public static class CommandFactory
             Description = $"Destination path for the generated {extension} file",
             Required = true
         };
-        var appName = new Option<string>("--application-name")
-        {
-            Description = "Application name",
-            Required = false
-        };
-        appName.Aliases.Add("--productName");
-        appName.Aliases.Add("--appName");
-        var startupWmClass = new Option<string>("--wm-class")
-        {
-            Description = "Startup WM Class",
-            Required = false
-        };
-        var mainCategory = new Option<MainCategory?>("--main-category")
-        {
-            Description = "Main category",
-            Required = false,
-            Arity = ArgumentArity.ZeroOrOne,
-        };
-        var additionalCategories = new Option<IEnumerable<AdditionalCategory>>("--additional-categories")
-        {
-            Description = "Additional categories",
-            Required = false,
-            Arity = ArgumentArity.ZeroOrMore,
-            AllowMultipleArgumentsPerToken = true
-        };
-        var keywords = new Option<IEnumerable<string>>("--keywords")
-        {
-            Description = "Keywords",
-            Required = false,
-            Arity = ArgumentArity.ZeroOrMore,
-            AllowMultipleArgumentsPerToken = true
-        };
-        var comment = new Option<string>("--comment")
-        {
-            Description = "Comment",
-            Required = false
-        };
-        var version = new Option<string>("--version")
-        {
-            Description = "Version",
-            Required = false
-        };
-        var homePage = new Option<Uri>("--homepage")
-        {
-            Description = "Home page of the application",
-            Required = false
-        };
-        homePage.CustomParser = OptionsBinder.GetUri;
-        var license = new Option<string>("--license")
-        {
-            Description = "License of the application",
-            Required = false
-        };
-        var screenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls")
-        {
-            Description = "Screenshot URLs",
-            Required = false
-        };
-        screenshotUrls.CustomParser = OptionsBinder.GetUris;
-        var summary = new Option<string>("--summary")
-        {
-            Description = "Summary. Short description that should not end in a dot.",
-            Required = false
-        };
-        var appId = new Option<string>("--appId")
-        {
-            Description = "Application Id. Usually a Reverse DNS name like com.SomeCompany.SomeApplication",
-            Required = false
-        };
-        var executableName = new Option<string>("--executable-name")
-        {
-            Description = "Name of your application's executable",
-            Required = false
-        };
-        var isTerminal = new Option<bool>("--is-terminal")
-        {
-            Description = "Indicates whether your application is a terminal application",
-            Required = false
-        };
-        var iconOption = new Option<IIcon?>("--icon")
-        {
-            Required = false,
-            Description = "Path to the application icon"
-        };
-        iconOption.CustomParser = OptionsBinder.GetIcon;
+
+        var metadata = new MetadataOptionSet();
 
         var defaultDescription = description ??
                                  $"Create a {friendlyName} from a directory with the published application contents. Everything is inferred. For .NET apps this is usually the 'publish' directory.";
@@ -124,49 +42,20 @@ public static class CommandFactory
 
         fromBuildDir.Add(buildDir);
         fromBuildDir.Add(outputFileOption);
-        fromBuildDir.Add(appName);
-        fromBuildDir.Add(startupWmClass);
-        fromBuildDir.Add(mainCategory);
-        fromBuildDir.Add(keywords);
-        fromBuildDir.Add(comment);
-        fromBuildDir.Add(iconOption);
-        fromBuildDir.Add(additionalCategories);
-        fromBuildDir.Add(version);
-        fromBuildDir.Add(homePage);
-        fromBuildDir.Add(license);
-        fromBuildDir.Add(screenshotUrls);
-        fromBuildDir.Add(summary);
-        fromBuildDir.Add(appId);
-        fromBuildDir.Add(executableName);
-        fromBuildDir.Add(isTerminal);
+        metadata.AddTo(fromBuildDir);
         if (defaultLayoutOption != null)
         {
             fromBuildDir.Add(defaultLayoutOption);
         }
 
-        var options = new OptionsBinder(
-            appName,
-            startupWmClass,
-            keywords,
-            comment,
-            mainCategory,
-            additionalCategories,
-            iconOption,
-            version,
-            homePage,
-            license,
-            screenshotUrls,
-            summary,
-            appId,
-            executableName,
-            isTerminal,
-            defaultLayoutOption);
+        var options = metadata.CreateBinder(defaultLayoutOption);
 
         fromBuildDir.SetAction(async parseResult =>
         {
             var directory = parseResult.GetValue(buildDir)!;
             var output = parseResult.GetValue(outputFileOption)!;
             var opts = options.Bind(parseResult);
+            optionsPostProcessor?.Invoke(opts, parseResult);
             await ExecutionWrapper.ExecuteWithLogging(commandName, output.FullName, logger => handler(directory, output, opts, logger));
         });
         return fromBuildDir;

--- a/src/DotnetPackaging.Tool/Commands/DebCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/DebCommand.cs
@@ -13,6 +13,12 @@ public static class DebCommand
 {
     public static Command GetCommand()
     {
+        var serviceOption = new Option<bool>("--service") { Description = "Install as a systemd service/daemon" };
+        var serviceTypeOption = new Option<string?>("--service-type") { Description = "systemd service type: simple (default), notify, forking, oneshot" };
+        var serviceRestartOption = new Option<string?>("--service-restart") { Description = "Restart policy: on-failure (default), always, no, on-abnormal, on-abort" };
+        var serviceUserOption = new Option<string?>("--service-user") { Description = "User to run the service as" };
+        var serviceEnvironmentOption = new Option<IEnumerable<string>>("--service-environment") { Description = "Environment variables (e.g., DOTNET_ENVIRONMENT=Production)", Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
+
         var command = CommandFactory.CreateCommand(
             "deb",
             "Debian package",
@@ -20,11 +26,34 @@ public static class DebCommand
             CreateDeb,
             "Create a Debian (.deb) installer for Debian and Ubuntu based distributions.",
             null,
+            (opts, parseResult) => ApplyServiceOptions(opts, parseResult, serviceOption, serviceTypeOption, serviceRestartOption, serviceUserOption, serviceEnvironmentOption),
             "pack-deb",
             "debian");
 
-        AddFromProjectSubcommand(command);
+        command.Add(serviceOption);
+        command.Add(serviceTypeOption);
+        command.Add(serviceRestartOption);
+        command.Add(serviceUserOption);
+        command.Add(serviceEnvironmentOption);
+
+        AddFromProjectSubcommand(command, serviceOption, serviceTypeOption, serviceRestartOption, serviceUserOption, serviceEnvironmentOption);
         return command;
+    }
+
+    private static void ApplyServiceOptions(Options opts, ParseResult parseResult, Option<bool> serviceOption, Option<string?> serviceTypeOption, Option<string?> serviceRestartOption, Option<string?> serviceUserOption, Option<IEnumerable<string>> serviceEnvironmentOption)
+    {
+        var isServiceEnabled = parseResult.GetValue(serviceOption);
+        if (!isServiceEnabled) return;
+
+        opts.IsService = true;
+        var svcType = parseResult.GetValue(serviceTypeOption);
+        if (svcType != null) opts.ServiceType = ParseServiceType(svcType);
+        var svcRestart = parseResult.GetValue(serviceRestartOption);
+        if (svcRestart != null) opts.ServiceRestart = ParseRestartPolicy(svcRestart);
+        var svcUser = parseResult.GetValue(serviceUserOption);
+        if (svcUser != null) opts.ServiceUser = svcUser;
+        var svcEnv = parseResult.GetValue(serviceEnvironmentOption)?.ToList();
+        if (svcEnv != null && svcEnv.Count > 0) opts.ServiceEnvironment = Maybe<IEnumerable<string>>.From(svcEnv);
     }
 
     private static Task CreateDeb(DirectoryInfo inputDir, FileInfo outputFile, Options options, ILogger logger)
@@ -42,98 +71,39 @@ public static class DebCommand
             .WriteResult();
     }
 
-    private static void AddFromProjectSubcommand(Command debCommand)
+    private static void AddFromProjectSubcommand(Command debCommand, Option<bool> serviceOption, Option<string?> serviceTypeOption, Option<string?> serviceRestartOption, Option<string?> serviceUserOption, Option<IEnumerable<string>> serviceEnvironmentOption)
     {
-        var project = new Option<FileInfo>("--project") { Description = "Path to the .csproj file", Required = true };
-        var arch = new Option<string?>("--arch") { Description = "Target architecture (x64, arm64). Auto-detects from current system if not specified." };
-        var selfContained = new Option<bool>("--self-contained") { Description = "Publish self-contained [Deprecated]" };
-        selfContained.DefaultValueFactory = _ => true;
-        var configuration = new Option<string>("--configuration") { Description = "Build configuration" };
-        configuration.DefaultValueFactory = _ => "Release";
-        var singleFile = new Option<bool>("--single-file") { Description = "Publish single-file" };
-        var trimmed = new Option<bool>("--trimmed") { Description = "Enable trimming" };
-        var output = new Option<FileInfo>("--output") { Description = "Destination path for the generated .deb", Required = true };
-
-        var appName = new Option<string>("--application-name") { Description = "Application name", Required = false };
-        appName.Aliases.Add("--productName");
-        appName.Aliases.Add("--appName");
-        var startupWmClass = new Option<string>("--wm-class") { Description = "Startup WM Class", Required = false };
-        var mainCategory = new Option<MainCategory?>("--main-category") { Description = "Main category", Required = false, Arity = ArgumentArity.ZeroOrOne, };
-        var additionalCategories = new Option<IEnumerable<AdditionalCategory>>("--additional-categories") { Description = "Additional categories", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var keywords = new Option<IEnumerable<string>>("--keywords") { Description = "Keywords", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var comment = new Option<string>("--comment") { Description = "Comment", Required = false };
-        var version = new Option<string>("--version") { Description = "Version", Required = false };
-        var homePage = new Option<Uri>("--homepage") { Description = "Home page of the application", Required = false };
-        homePage.CustomParser = OptionsBinder.GetUri;
-        var license = new Option<string>("--license") { Description = "License of the application", Required = false };
-        var screenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls") { Description = "Screenshot URLs", Required = false };
-        screenshotUrls.CustomParser = OptionsBinder.GetUris;
-        var summary = new Option<string>("--summary") { Description = "Summary. Short description that should not end in a dot.", Required = false };
-        var appId = new Option<string>("--appId") { Description = "Application Id. Usually a Reverse DNS name like com.SomeCompany.SomeApplication", Required = false };
-        var executableName = new Option<string>("--executable-name") { Description = "Name of your application's executable", Required = false };
-        var isTerminal = new Option<bool>("--is-terminal") { Description = "Indicates whether your application is a terminal application", Required = false };
-        var iconOption = new Option<IIcon?>("--icon") { Required = false, Description = "Path to the application icon" };
-        iconOption.CustomParser = OptionsBinder.GetIcon;
-
-        var optionsBinder = new OptionsBinder(appName, startupWmClass, keywords, comment, mainCategory, additionalCategories, iconOption, version, homePage, license, screenshotUrls, summary, appId, executableName, isTerminal);
+        var metadata = new MetadataOptionSet();
+        var project = new ProjectOptionSet(".deb");
 
         var fromProject = new Command("from-project") { Description = "Publish a .NET project and build a Debian .deb from the published output." };
-        fromProject.Add(project);
-        fromProject.Add(arch);
-        fromProject.Add(selfContained);
-        fromProject.Add(configuration);
-        fromProject.Add(singleFile);
-        fromProject.Add(trimmed);
-        fromProject.Add(output);
-        fromProject.Add(appName);
-        fromProject.Add(startupWmClass);
-        fromProject.Add(mainCategory);
-        fromProject.Add(additionalCategories);
-        fromProject.Add(keywords);
-        fromProject.Add(comment);
-        fromProject.Add(version);
-        fromProject.Add(homePage);
-        fromProject.Add(license);
-        fromProject.Add(screenshotUrls);
-        fromProject.Add(summary);
-        fromProject.Add(appId);
-        fromProject.Add(executableName);
-        fromProject.Add(isTerminal);
-        fromProject.Add(iconOption);
+        project.AddTo(fromProject);
+        metadata.AddTo(fromProject);
+        fromProject.Add(serviceOption);
+        fromProject.Add(serviceTypeOption);
+        fromProject.Add(serviceRestartOption);
+        fromProject.Add(serviceUserOption);
+        fromProject.Add(serviceEnvironmentOption);
+
+        var binder = metadata.CreateBinder();
 
         fromProject.SetAction(async parseResult =>
         {
-            var prj = parseResult.GetValue(project)!;
-            var sc = parseResult.GetValue(selfContained);
-            var cfg = parseResult.GetValue(configuration)!;
-            var sf = parseResult.GetValue(singleFile);
-            var tr = parseResult.GetValue(trimmed);
-            var outFile = parseResult.GetValue(output)!;
-            var opt = optionsBinder.Bind(parseResult);
-            var archVal = parseResult.GetValue(arch);
+            var prj = parseResult.GetValue(project.Project)!;
+            var cfg = parseResult.GetValue(project.Configuration)!;
+            var sf = parseResult.GetValue(project.SingleFile);
+            var tr = parseResult.GetValue(project.Trimmed);
+            var outFile = parseResult.GetValue(project.Output)!;
+            var opt = binder.Bind(parseResult);
+            var archVal = parseResult.GetValue(project.Arch);
             var logger = Log.ForContext("command", "deb-from-project");
 
-            // Auto-detect architecture if not specified
+            ApplyServiceOptions(opt, parseResult, serviceOption, serviceTypeOption, serviceRestartOption, serviceUserOption, serviceEnvironmentOption);
+
             if (archVal == null)
             {
-                archVal = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture switch
-                {
-                    System.Runtime.InteropServices.Architecture.X64 => "x64",
-                    System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
-                    System.Runtime.InteropServices.Architecture.Arm => "arm",
-                    System.Runtime.InteropServices.Architecture.X86 => "x86",
-                    _ => null
-                };
-
-                if (archVal != null)
-                {
-                    logger.Information("Architecture not specified, auto-detected: {Arch}", archVal);
-                }
-                else
-                {
-                    logger.Error("Unable to auto-detect architecture. Please specify --arch explicitly (e.g., --arch x64)");
-                    return;
-                }
+                archVal = ProjectOptionSet.AutoDetectArch(logger);
+                if (archVal == null) return;
             }
 
             var result = await new Deb.DebPackager().PackProject(
@@ -164,4 +134,25 @@ public static class DebCommand
 
         debCommand.Add(fromProject);
     }
+
+    private static ServiceType ParseServiceType(string value) => value.ToLowerInvariant() switch
+    {
+        "simple" => ServiceType.Simple,
+        "notify" => ServiceType.Notify,
+        "forking" => ServiceType.Forking,
+        "oneshot" => ServiceType.OneShot,
+        "idle" => ServiceType.Idle,
+        _ => ServiceType.Simple
+    };
+
+    private static RestartPolicy ParseRestartPolicy(string value) => value.ToLowerInvariant() switch
+    {
+        "no" => RestartPolicy.No,
+        "always" => RestartPolicy.Always,
+        "on-failure" => RestartPolicy.OnFailure,
+        "on-abnormal" => RestartPolicy.OnAbnormal,
+        "on-abort" => RestartPolicy.OnAbort,
+        "on-watchdog" => RestartPolicy.OnWatchdog,
+        _ => RestartPolicy.OnFailure
+    };
 }

--- a/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
@@ -31,6 +31,7 @@ public static class DmgCommand
             CreateDmg,
             "Create a macOS disk image (.dmg) with a native HFS+ payload wrapped in UDIF (DMG) format.",
             defaultLayoutOption,
+            null,
             "pack-dmg");
 
         AddDmgFromProjectSubcommand(dmgCommand);
@@ -91,74 +92,30 @@ public static class DmgCommand
 
     private static void AddDmgFromProjectSubcommand(Command dmgCommand)
     {
-        var project = new Option<FileInfo>("--project") { Description = "Path to the .csproj file", Required = true };
-        var arch = new Option<string?>("--arch") { Description = "Target architecture (x64, arm64)" };
-        var selfContained = new Option<bool>("--self-contained") { Description = "Publish self-contained [Deprecated]" };
-        selfContained.DefaultValueFactory = _ => true;
-        var configuration = new Option<string>("--configuration") { Description = "Build configuration" };
-        configuration.DefaultValueFactory = _ => "Release";
-        var singleFile = new Option<bool>("--single-file") { Description = "Publish single-file" };
-        singleFile.DefaultValueFactory = _ => true;
-        var trimmed = new Option<bool>("--trimmed") { Description = "Enable trimming" };
-        var output = new Option<FileInfo>("--output") { Description = "Output .dmg file", Required = true };
+        var metadata = new MetadataOptionSet();
+        var project = new ProjectOptionSet(".dmg", singleFileDefault: true);
         var compress = new Option<bool>("--compress") { Description = "Compress the DMG payload (bzip2/UDZO-like)" };
         compress.DefaultValueFactory = _ => true;
         var defaultLayoutOption = new Option<bool>("--with-default-layout") { Description = "Add a default Finder layout (background image, Applications link positioning) when none is provided" };
         defaultLayoutOption.DefaultValueFactory = _ => true;
 
-        // Reuse metadata options to get volume name from --application-name if present
-        var appName = new Option<string>("--application-name") { Description = "Application name / volume name", Required = false };
-        appName.Aliases.Add("--productName");
-        appName.Aliases.Add("--appName");
-        var dmgIconOption = new Option<IIcon?>("--icon") { Description = "Path to the application icon" };
-        dmgIconOption.CustomParser = OptionsBinder.GetIcon;
-
-        var homePage = new Option<Uri>("--homepage") { Description = "Home page of the application", Required = false };
-        homePage.CustomParser = OptionsBinder.GetUri;
-        var screenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls") { Description = "Screenshot URLs", Required = false };
-        screenshotUrls.CustomParser = OptionsBinder.GetUris;
-
-        var optionsBinder = new OptionsBinder(appName,
-            new Option<string>("--wm-class"),
-            new Option<IEnumerable<string>>("--keywords"),
-            new Option<string>("--comment"),
-            new Option<MainCategory?>("--main-category"),
-            new Option<IEnumerable<AdditionalCategory>>("--additional-categories"),
-            dmgIconOption,
-            new Option<string>("--version"),
-            homePage,
-            new Option<string>("--license"),
-            screenshotUrls,
-            new Option<string>("--summary"),
-            new Option<string>("--appId"),
-            new Option<string>("--executable-name"),
-            new Option<bool>("--is-terminal"),
-            defaultLayoutOption);
+        var binder = metadata.CreateBinder(defaultLayoutOption);
 
         var fromProject = new Command("from-project") { Description = "Publish a .NET project and build a .dmg from the published output (.app bundle auto-generated if missing). Experimental." };
-        fromProject.Add(project);
-        fromProject.Add(arch);
-        fromProject.Add(selfContained);
-        fromProject.Add(configuration);
-        fromProject.Add(singleFile);
-        fromProject.Add(trimmed);
-        fromProject.Add(output);
-        fromProject.Add(appName);
+        project.AddTo(fromProject);
+        metadata.AddTo(fromProject);
         fromProject.Add(compress);
         fromProject.Add(defaultLayoutOption);
-        fromProject.Add(homePage);
-        fromProject.Add(screenshotUrls);
 
         fromProject.SetAction(async parseResult =>
         {
-            var prj = parseResult.GetValue(project)!;
-            var sc = parseResult.GetValue(selfContained);
-            var cfg = parseResult.GetValue(configuration)!;
-            var sf = parseResult.GetValue(singleFile);
-            var tr = parseResult.GetValue(trimmed);
-            var outFile = parseResult.GetValue(output)!;
-            var opt = optionsBinder.Bind(parseResult);
-            var ridVal = parseResult.GetValue(arch);
+            var prj = parseResult.GetValue(project.Project)!;
+            var cfg = parseResult.GetValue(project.Configuration)!;
+            var sf = parseResult.GetValue(project.SingleFile);
+            var tr = parseResult.GetValue(project.Trimmed);
+            var outFile = parseResult.GetValue(project.Output)!;
+            var opt = binder.Bind(parseResult);
+            var ridVal = parseResult.GetValue(project.Arch);
             var compressVal = parseResult.GetValue(compress);
             var useDefaultLayout = opt.UseDefaultLayout.GetValueOrDefault(true);
             var logger = Log.ForContext("command", "dmg-from-project");

--- a/src/DotnetPackaging.Tool/Commands/ExeCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/ExeCommand.cs
@@ -40,91 +40,30 @@ public static class ExeCommand
         {
             Description = "Target architecture for the stub (x64, arm64)"
         };
-
-        // Reuse metadata options
-        var exAppName = new Option<string>("--application-name")
-        {
-            Description = "Application name",
-            Required = false
-        };
-        exAppName.Aliases.Add("--productName");
-        exAppName.Aliases.Add("--appName");
-        var exComment = new Option<string>("--comment")
-        {
-            Description = "Comment / long description",
-            Required = false
-        };
-        var exVersion = new Option<string>("--version")
-        {
-            Description = "Version",
-            Required = false
-        };
-        var exAppId = new Option<string>("--appId")
-        {
-            Description = "Application Id (Reverse DNS typical)",
-            Required = false
-        };
         var exVendor = new Option<string>("--vendor")
         {
             Description = "Vendor/Publisher",
             Required = false
         };
         exVendor.Aliases.Add("--company");
-        var exExecutableName = new Option<string>("--executable-name")
-        {
-            Description = "Name of your application's executable",
-            Required = false
-        };
-        var exIconOption = new Option<IIcon?>("--icon")
-        {
-            Description = "Path to the application icon"
-        };
-        exIconOption.CustomParser = OptionsBinder.GetIcon;
 
-        var homePage = new Option<Uri>("--homepage") { Description = "Home page of the application", Required = false };
-        homePage.CustomParser = OptionsBinder.GetUri;
-        var screenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls") { Description = "Screenshot URLs", Required = false };
-        screenshotUrls.CustomParser = OptionsBinder.GetUris;
-
-        var optionsBinder = new OptionsBinder(
-            exAppName,
-            new Option<string>("--wm-class"),
-            new Option<IEnumerable<string>>("--keywords"),
-            exComment,
-            new Option<MainCategory?>("--main-category"),
-            new Option<IEnumerable<AdditionalCategory>>("--additional-categories"),
-            exIconOption,
-            exVersion,
-            homePage,
-            new Option<string>("--license"),
-            screenshotUrls,
-            new Option<string>("--summary"),
-            exAppId,
-            exExecutableName,
-            new Option<bool>("--is-terminal")
-        );
+        var metadata = new MetadataOptionSet();
+        var optionsBinder = metadata.CreateBinder();
 
         exeCommand.Add(exeInputDir);
         exeCommand.Add(exeOutput);
         exeCommand.Add(stubPath);
         exeCommand.Add(setupLogo);
-        // Make metadata options global so subcommands can use them without re-adding
-        exAppName.Recursive = true;
-        exComment.Recursive = true;
-        exVersion.Recursive = true;
-        exAppId.Recursive = true;
+        metadata.ApplicationName.Recursive = true;
+        metadata.Comment.Recursive = true;
+        metadata.Version.Recursive = true;
+        metadata.AppId.Recursive = true;
         exVendor.Recursive = true;
-        exExecutableName.Recursive = true;
+        metadata.ExecutableName.Recursive = true;
         setupLogo.Recursive = true;
-        exeCommand.Add(exAppName);
-        exeCommand.Add(exComment);
-        exeCommand.Add(exVersion);
-        exeCommand.Add(exAppId);
+        metadata.AddTo(exeCommand);
         exeCommand.Add(exVendor);
-        exeCommand.Add(exExecutableName);
         exeCommand.Add(exArchTop);
-        exeCommand.Add(homePage);
-        exeCommand.Add(screenshotUrls);
 
         exeCommand.SetAction(async parseResult =>
         {
@@ -157,7 +96,7 @@ public static class ExeCommand
                     : null;
 
                 var packager = new ExePackager(logger: logger);
-                var metadata = new ExePackagerMetadata
+                var exeMetadata = new ExePackagerMetadata
                 {
                     Options = opt,
                     Vendor = Maybe.From(vendorOpt),
@@ -167,7 +106,7 @@ public static class ExeCommand
                     OutputName = Maybe.From(outFile.Name)
                 };
 
-                var result = await packager.Pack(containerResult, metadata);
+                var result = await packager.Pack(containerResult, exeMetadata);
                 if (result.IsFailure)
                 {
                     logger.Error("EXE packaging failed: {Error}", result.Error);
@@ -187,38 +126,7 @@ public static class ExeCommand
         });
 
         // exe from-project
-        var exProject = new Option<FileInfo>("--project")
-        {
-            Description = "Path to the .csproj file",
-            Required = true
-        };
-        var exArch = new Option<string?>("--arch")
-        {
-            Description = "Target architecture (x64, arm64)"
-        };
-        var exSelfContained = new Option<bool>("--self-contained")
-        {
-            Description = "Publish self-contained [Deprecated]"
-        };
-        exSelfContained.DefaultValueFactory = _ => true;
-        var exConfiguration = new Option<string>("--configuration")
-        {
-            Description = "Build configuration"
-        };
-        exConfiguration.DefaultValueFactory = _ => "Release";
-        var exSingleFile = new Option<bool>("--single-file")
-        {
-            Description = "Publish single-file"
-        };
-        var exTrimmed = new Option<bool>("--trimmed")
-        {
-            Description = "Enable trimming"
-        };
-        var exOut = new Option<FileInfo>("--output")
-        {
-            Description = "Output installer .exe",
-            Required = true
-        };
+        var project = new ProjectOptionSet(".exe");
         var exStub = new Option<FileInfo>("--stub")
         {
             Description = "Path to the prebuilt stub (WinExe) to concatenate (optional if repo layout is present)"
@@ -229,25 +137,18 @@ public static class ExeCommand
         };
 
         var exFromProject = new Command("from-project") { Description = "Publish a .NET project and build a Windows self-extracting installer (.exe). If --stub is not provided, the tool downloads the appropriate stub from GitHub Releases." };
-        exFromProject.Add(exProject);
-        exFromProject.Add(exArch);
-        exFromProject.Add(exSelfContained);
-        exFromProject.Add(exConfiguration);
-        exFromProject.Add(exSingleFile);
-        exFromProject.Add(exTrimmed);
-        exFromProject.Add(exOut);
+        project.AddTo(exFromProject);
         exFromProject.Add(exStub);
         exFromProject.Add(exSetupLogo);
 
         exFromProject.SetAction(async parseResult =>
         {
-            var prj = parseResult.GetValue(exProject)!;
-            var archVal = parseResult.GetValue(exArch);
-            var sc = parseResult.GetValue(exSelfContained);
-            var cfg = parseResult.GetValue(exConfiguration)!;
-            var sf = parseResult.GetValue(exSingleFile);
-            var tr = parseResult.GetValue(exTrimmed);
-            var extrasOutput = parseResult.GetValue(exOut)!;
+            var prj = parseResult.GetValue(project.Project)!;
+            var archVal = parseResult.GetValue(project.Arch);
+            var cfg = parseResult.GetValue(project.Configuration)!;
+            var sf = parseResult.GetValue(project.SingleFile);
+            var tr = parseResult.GetValue(project.Trimmed);
+            var extrasOutput = parseResult.GetValue(project.Output)!;
             var extrasStub = parseResult.GetValue(exStub);
             var extrasLogo = parseResult.GetValue(exSetupLogo);
             var vendorOpt = parseResult.GetValue(exVendor);

--- a/src/DotnetPackaging.Tool/Commands/MetadataOptionSet.cs
+++ b/src/DotnetPackaging.Tool/Commands/MetadataOptionSet.cs
@@ -1,0 +1,70 @@
+using System.CommandLine;
+
+namespace DotnetPackaging.Tool.Commands;
+
+public class MetadataOptionSet
+{
+    public Option<string> ApplicationName { get; }
+    public Option<string> WmClass { get; }
+    public Option<MainCategory?> MainCategory { get; }
+    public Option<IEnumerable<AdditionalCategory>> AdditionalCategories { get; }
+    public Option<IEnumerable<string>> Keywords { get; }
+    public Option<string> Comment { get; }
+    public Option<string> Version { get; }
+    public Option<Uri> HomePage { get; }
+    public Option<string> License { get; }
+    public Option<IEnumerable<Uri>> ScreenshotUrls { get; }
+    public Option<string> Summary { get; }
+    public Option<string> AppId { get; }
+    public Option<string> ExecutableName { get; }
+    public Option<bool> IsTerminal { get; }
+    public Option<IIcon?> Icon { get; }
+
+    public MetadataOptionSet()
+    {
+        ApplicationName = new Option<string>("--application-name") { Description = "Application name", Required = false };
+        ApplicationName.Aliases.Add("--productName");
+        ApplicationName.Aliases.Add("--appName");
+        WmClass = new Option<string>("--wm-class") { Description = "Startup WM Class", Required = false };
+        MainCategory = new Option<MainCategory?>("--main-category") { Description = "Main category", Required = false, Arity = ArgumentArity.ZeroOrOne };
+        AdditionalCategories = new Option<IEnumerable<AdditionalCategory>>("--additional-categories") { Description = "Additional categories", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
+        Keywords = new Option<IEnumerable<string>>("--keywords") { Description = "Keywords", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
+        Comment = new Option<string>("--comment") { Description = "Comment", Required = false };
+        Version = new Option<string>("--version") { Description = "Version", Required = false };
+        HomePage = new Option<Uri>("--homepage") { Description = "Home page of the application", Required = false };
+        HomePage.CustomParser = OptionsBinder.GetUri;
+        License = new Option<string>("--license") { Description = "License of the application", Required = false };
+        ScreenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls") { Description = "Screenshot URLs", Required = false };
+        ScreenshotUrls.CustomParser = OptionsBinder.GetUris;
+        Summary = new Option<string>("--summary") { Description = "Summary. Short description that should not end in a dot.", Required = false };
+        AppId = new Option<string>("--appId") { Description = "Application Id. Usually a Reverse DNS name like com.SomeCompany.SomeApplication", Required = false };
+        ExecutableName = new Option<string>("--executable-name") { Description = "Name of your application's executable", Required = false };
+        IsTerminal = new Option<bool>("--is-terminal") { Description = "Indicates whether your application is a terminal application", Required = false };
+        Icon = new Option<IIcon?>("--icon") { Required = false, Description = "Path to the application icon" };
+        Icon.CustomParser = OptionsBinder.GetIcon;
+    }
+
+    public void AddTo(Command command)
+    {
+        command.Add(ApplicationName);
+        command.Add(WmClass);
+        command.Add(MainCategory);
+        command.Add(AdditionalCategories);
+        command.Add(Keywords);
+        command.Add(Comment);
+        command.Add(Version);
+        command.Add(HomePage);
+        command.Add(License);
+        command.Add(ScreenshotUrls);
+        command.Add(Summary);
+        command.Add(AppId);
+        command.Add(ExecutableName);
+        command.Add(IsTerminal);
+        command.Add(Icon);
+    }
+
+    public OptionsBinder CreateBinder(Option<bool>? defaultLayout = null) =>
+        new(ApplicationName, WmClass, Keywords, Comment, MainCategory,
+            AdditionalCategories, Icon, Version, HomePage, License, ScreenshotUrls,
+            Summary, AppId, ExecutableName, IsTerminal, defaultLayout);
+}

--- a/src/DotnetPackaging.Tool/Commands/MsixCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/MsixCommand.cs
@@ -49,32 +49,17 @@ public static class MsixCommand
         });
         msixCommand.Add(packCmd);
 
-        var project = new Option<FileInfo>("--project") { Description = "Path to the .csproj file", Required = true };
-        var arch = new Option<string?>("--arch") { Description = "Target architecture (x64, arm64)" };
-        var selfContained = new Option<bool>("--self-contained") { Description = "Publish self-contained [Deprecated]" };
-        selfContained.DefaultValueFactory = _ => true;
-        var configuration = new Option<string>("--configuration") { Description = "Build configuration" };
-        configuration.DefaultValueFactory = _ => "Release";
-        var singleFile = new Option<bool>("--single-file") { Description = "Publish single-file" };
-        var trimmed = new Option<bool>("--trimmed") { Description = "Enable trimming" };
-        var outMsix = new Option<FileInfo>("--output") { Description = "Output .msix file", Required = true };
+        var project = new ProjectOptionSet(".msix");
         var fromProject = new Command("from-project") { Description = "Publish a .NET project and build an MSIX from the published output (expects manifest/assets)." };
-        fromProject.Add(project);
-        fromProject.Add(arch);
-        fromProject.Add(selfContained);
-        fromProject.Add(configuration);
-        fromProject.Add(singleFile);
-        fromProject.Add(trimmed);
-        fromProject.Add(outMsix);
+        project.AddTo(fromProject);
         fromProject.SetAction(async parseResult =>
         {
-            var prj = parseResult.GetValue(project)!;
-            var sc = parseResult.GetValue(selfContained);
-            var cfg = parseResult.GetValue(configuration)!;
-            var sf = parseResult.GetValue(singleFile);
-            var tr = parseResult.GetValue(trimmed);
-            var outFile = parseResult.GetValue(outMsix)!;
-            var archVal = parseResult.GetValue(arch);
+            var prj = parseResult.GetValue(project.Project)!;
+            var cfg = parseResult.GetValue(project.Configuration)!;
+            var sf = parseResult.GetValue(project.SingleFile);
+            var tr = parseResult.GetValue(project.Trimmed);
+            var outFile = parseResult.GetValue(project.Output)!;
+            var archVal = parseResult.GetValue(project.Arch);
             var logger = Log.ForContext("command", "msix-from-project");
 
             var result = await new MsixPackager().PackProject(

--- a/src/DotnetPackaging.Tool/Commands/ProjectOptionSet.cs
+++ b/src/DotnetPackaging.Tool/Commands/ProjectOptionSet.cs
@@ -1,0 +1,67 @@
+using System.CommandLine;
+using System.Runtime.InteropServices;
+using Serilog;
+
+namespace DotnetPackaging.Tool.Commands;
+
+public class ProjectOptionSet
+{
+    public Option<FileInfo> Project { get; }
+    public Option<string?> Arch { get; }
+    public Option<bool> SelfContained { get; }
+    public Option<string> Configuration { get; }
+    public Option<bool> SingleFile { get; }
+    public Option<bool> Trimmed { get; }
+    public Option<FileInfo> Output { get; }
+
+    public ProjectOptionSet(string extension, bool singleFileDefault = false)
+    {
+        Project = new Option<FileInfo>("--project") { Description = "Path to the .csproj file", Required = true };
+        Arch = new Option<string?>("--arch") { Description = "Target architecture (x64, arm64). Auto-detects from current system if not specified." };
+        SelfContained = new Option<bool>("--self-contained") { Description = "Publish self-contained [Deprecated]" };
+        SelfContained.DefaultValueFactory = _ => true;
+        Configuration = new Option<string>("--configuration") { Description = "Build configuration" };
+        Configuration.DefaultValueFactory = _ => "Release";
+        SingleFile = new Option<bool>("--single-file") { Description = "Publish single-file" };
+        if (singleFileDefault)
+        {
+            SingleFile.DefaultValueFactory = _ => true;
+        }
+        Trimmed = new Option<bool>("--trimmed") { Description = "Enable trimming" };
+        Output = new Option<FileInfo>("--output") { Description = $"Destination path for the generated {extension}", Required = true };
+    }
+
+    public void AddTo(Command command)
+    {
+        command.Add(Project);
+        command.Add(Arch);
+        command.Add(SelfContained);
+        command.Add(Configuration);
+        command.Add(SingleFile);
+        command.Add(Trimmed);
+        command.Add(Output);
+    }
+
+    public static string? AutoDetectArch(ILogger logger)
+    {
+        var arch = RuntimeInformation.ProcessArchitecture switch
+        {
+            System.Runtime.InteropServices.Architecture.X64 => "x64",
+            System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
+            System.Runtime.InteropServices.Architecture.Arm => "arm",
+            System.Runtime.InteropServices.Architecture.X86 => "x86",
+            _ => null
+        };
+
+        if (arch != null)
+        {
+            logger.Information("Architecture not specified, auto-detected: {Arch}", arch);
+        }
+        else
+        {
+            logger.Error("Unable to auto-detect architecture. Please specify --arch explicitly (e.g., --arch x64)");
+        }
+
+        return arch;
+    }
+}

--- a/src/DotnetPackaging.Tool/Commands/RpmCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/RpmCommand.cs
@@ -19,6 +19,7 @@ public static class RpmCommand
             CreateRpm,
             "Create an RPM (.rpm) package suitable for Fedora, openSUSE, and other RPM-based distributions.",
             null,
+            null,
             "pack-rpm");
 
         AddFromProjectSubcommand(command);
@@ -42,96 +43,30 @@ public static class RpmCommand
 
     private static void AddFromProjectSubcommand(Command rpmCommand)
     {
-        var project = new Option<FileInfo>("--project") { Description = "Path to the .csproj file", Required = true };
-        var arch = new Option<string?>("--arch") { Description = "Target architecture (x64, arm64). Auto-detects from current system if not specified." };
-        var selfContained = new Option<bool>("--self-contained") { Description = "Publish self-contained [Deprecated]" };
-        selfContained.DefaultValueFactory = _ => true;
-        var configuration = new Option<string>("--configuration") { Description = "Build configuration" };
-        configuration.DefaultValueFactory = _ => "Release";
-        var singleFile = new Option<bool>("--single-file") { Description = "Publish single-file" };
-        var trimmed = new Option<bool>("--trimmed") { Description = "Enable trimming" };
-        var output = new Option<FileInfo>("--output") { Description = "Destination path for the generated .rpm", Required = true };
-
-        var appName = new Option<string>("--application-name") { Description = "Application name", Required = false };
-        appName.Aliases.Add("--productName");
-        appName.Aliases.Add("--appName");
-        var startupWmClass = new Option<string>("--wm-class") { Description = "Startup WM Class", Required = false };
-        var mainCategory = new Option<MainCategory?>("--main-category") { Description = "Main category", Required = false, Arity = ArgumentArity.ZeroOrOne, };
-        var additionalCategories = new Option<IEnumerable<AdditionalCategory>>("--additional-categories") { Description = "Additional categories", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var keywords = new Option<IEnumerable<string>>("--keywords") { Description = "Keywords", Required = false, Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
-        var comment = new Option<string>("--comment") { Description = "Comment", Required = false };
-        var version = new Option<string>("--version") { Description = "Version", Required = false };
-        var homePage = new Option<Uri>("--homepage") { Description = "Home page of the application", Required = false };
-        homePage.CustomParser = OptionsBinder.GetUri;
-        var license = new Option<string>("--license") { Description = "License of the application", Required = false };
-        var screenshotUrls = new Option<IEnumerable<Uri>>("--screenshot-urls") { Description = "Screenshot URLs", Required = false };
-        screenshotUrls.CustomParser = OptionsBinder.GetUris;
-        var summary = new Option<string>("--summary") { Description = "Summary. Short description that should not end in a dot.", Required = false };
-        var appId = new Option<string>("--appId") { Description = "Application Id. Usually a Reverse DNS name like com.SomeCompany.SomeApplication", Required = false };
-        var executableName = new Option<string>("--executable-name") { Description = "Name of your application's executable", Required = false };
-        var isTerminal = new Option<bool>("--is-terminal") { Description = "Indicates whether your application is a terminal application", Required = false };
-        var iconOption = new Option<IIcon?>("--icon") { Required = false, Description = "Path to the application icon" };
-        iconOption.CustomParser = OptionsBinder.GetIcon;
-
-        var optionsBinder = new OptionsBinder(appName, startupWmClass, keywords, comment, mainCategory, additionalCategories, iconOption, version, homePage, license, screenshotUrls, summary, appId, executableName, isTerminal);
+        var metadata = new MetadataOptionSet();
+        var project = new ProjectOptionSet(".rpm");
 
         var fromProject = new Command("from-project") { Description = "Publish a .NET project and build an RPM from the published output (no code duplication; library drives the pipeline)." };
-        fromProject.Add(project);
-        fromProject.Add(arch);
-        fromProject.Add(selfContained);
-        fromProject.Add(configuration);
-        fromProject.Add(singleFile);
-        fromProject.Add(trimmed);
-        fromProject.Add(output);
-        fromProject.Add(appName);
-        fromProject.Add(startupWmClass);
-        fromProject.Add(mainCategory);
-        fromProject.Add(additionalCategories);
-        fromProject.Add(keywords);
-        fromProject.Add(comment);
-        fromProject.Add(version);
-        fromProject.Add(homePage);
-        fromProject.Add(license);
-        fromProject.Add(screenshotUrls);
-        fromProject.Add(summary);
-        fromProject.Add(appId);
-        fromProject.Add(executableName);
-        fromProject.Add(isTerminal);
-        fromProject.Add(iconOption);
+        project.AddTo(fromProject);
+        metadata.AddTo(fromProject);
+
+        var binder = metadata.CreateBinder();
 
         fromProject.SetAction(async parseResult =>
         {
-            var prj = parseResult.GetValue(project)!;
-            var sc = parseResult.GetValue(selfContained);
-            var cfg = parseResult.GetValue(configuration)!;
-            var sf = parseResult.GetValue(singleFile);
-            var tr = parseResult.GetValue(trimmed);
-            var outFile = parseResult.GetValue(output)!;
-            var opt = optionsBinder.Bind(parseResult);
-            var archVal = parseResult.GetValue(arch);
+            var prj = parseResult.GetValue(project.Project)!;
+            var cfg = parseResult.GetValue(project.Configuration)!;
+            var sf = parseResult.GetValue(project.SingleFile);
+            var tr = parseResult.GetValue(project.Trimmed);
+            var outFile = parseResult.GetValue(project.Output)!;
+            var opt = binder.Bind(parseResult);
+            var archVal = parseResult.GetValue(project.Arch);
             var logger = Log.ForContext("command", "rpm-from-project");
 
-            // Auto-detect architecture if not specified
             if (archVal == null)
             {
-                archVal = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture switch
-                {
-                    System.Runtime.InteropServices.Architecture.X64 => "x64",
-                    System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
-                    System.Runtime.InteropServices.Architecture.Arm => "arm",
-                    System.Runtime.InteropServices.Architecture.X86 => "x86",
-                    _ => null
-                };
-
-                if (archVal != null)
-                {
-                    logger.Information("Architecture not specified, auto-detected: {Arch}", archVal);
-                }
-                else
-                {
-                    logger.Error("Unable to auto-detect architecture. Please specify --arch explicitly (e.g., --arch x64)");
-                    return;
-                }
+                archVal = ProjectOptionSet.AutoDetectArch(logger);
+                if (archVal == null) return;
             }
 
             var result = await new RpmPackager().PackProject(

--- a/src/DotnetPackaging/BuildUtils.cs
+++ b/src/DotnetPackaging/BuildUtils.cs
@@ -100,7 +100,8 @@ public static class BuildUtils
             InstalledSize = setup.InstalledSize,
             ModificationTime = setup.ModificationTime.GetValueOrDefault(DateTimeOffset.Now),
             Vendor = setup.Vendor,
-            Url = setup.Url
+            Url = setup.Url,
+            Service = setup.Service
         };
 
         return packageMetadata;

--- a/src/DotnetPackaging/FromDirectoryOptions.cs
+++ b/src/DotnetPackaging/FromDirectoryOptions.cs
@@ -34,6 +34,7 @@ public class FromDirectoryOptions
     public Maybe<ProjectMetadata> ProjectMetadata { get; private set; } = Maybe<ProjectMetadata>.None;
     public Maybe<string> Vendor { get; private set; } = Maybe<string>.None;
     public Maybe<Uri> Url { get; private set; } = Maybe<Uri>.None;
+    public Maybe<ServiceDefinition> Service { get; private set; } = Maybe<ServiceDefinition>.None;
 
     public FromDirectoryOptions WithPackage(string package)
     {
@@ -255,6 +256,14 @@ public class FromDirectoryOptions
     public FromDirectoryOptions WithUrl(Uri url)
     {
         Url = Maybe<Uri>.From(url);
+        return this;
+    }
+
+    public FromDirectoryOptions WithService(Action<ServiceDefinition>? configure = null)
+    {
+        var definition = new ServiceDefinition();
+        configure?.Invoke(definition);
+        Service = Maybe<ServiceDefinition>.From(definition);
         return this;
     }
 }

--- a/src/DotnetPackaging/FromDirectoryOptionsExtensions.cs
+++ b/src/DotnetPackaging/FromDirectoryOptionsExtensions.cs
@@ -42,6 +42,21 @@ public static class FromDirectoryOptionsExtensions
         if (source.Vendor.HasValue) target.WithVendor(source.Vendor.Value);
         if (source.Url.HasValue) target.WithUrl(source.Url.Value);
         if (source.IsTerminal.HasValue) target.WithIsTerminal(source.IsTerminal.Value);
+        if (source.Service.HasValue)
+        {
+            target.WithService(svc =>
+            {
+                var src = source.Service.Value;
+                if (src.Type.HasValue) svc.WithType(src.Type.Value);
+                if (src.Restart.HasValue) svc.WithRestart(src.Restart.Value);
+                if (src.RestartSec.HasValue) svc.WithRestartSec(src.RestartSec.Value);
+                if (src.User.HasValue) svc.WithUser(src.User.Value);
+                if (src.Group.HasValue) svc.WithGroup(src.Group.Value);
+                if (src.After.HasValue) svc.WithAfter(src.After.Value);
+                if (src.WantedBy.HasValue) svc.WithWantedBy(src.WantedBy.Value);
+                if (src.Environment.HasValue) svc.WithEnvironment(src.Environment.Value.ToArray());
+            });
+        }
 
         return target;
     }

--- a/src/DotnetPackaging/Options.cs
+++ b/src/DotnetPackaging/Options.cs
@@ -18,4 +18,9 @@ public class Options
     public Maybe<string> ExecutableName { get; set; }
     public Maybe<bool> IsTerminal { get; set; }
     public Maybe<bool> UseDefaultLayout { get; set; }
+    public Maybe<bool> IsService { get; set; }
+    public Maybe<ServiceType> ServiceType { get; set; }
+    public Maybe<RestartPolicy> ServiceRestart { get; set; }
+    public Maybe<string> ServiceUser { get; set; }
+    public Maybe<IEnumerable<string>> ServiceEnvironment { get; set; }
 }

--- a/src/DotnetPackaging/OptionsMixin.cs
+++ b/src/DotnetPackaging/OptionsMixin.cs
@@ -73,5 +73,16 @@ public static class OptionsMixin
                 options.AdditionalCategories.GetValueOrDefault(Array.Empty<AdditionalCategory>()).ToArray());
             setup.WithCategories(categories);
         }
+
+        if (options.IsService.HasValue && options.IsService.Value)
+        {
+            setup.WithService(svc =>
+            {
+                if (options.ServiceType.HasValue) svc.WithType(options.ServiceType.Value);
+                if (options.ServiceRestart.HasValue) svc.WithRestart(options.ServiceRestart.Value);
+                if (options.ServiceUser.HasValue) svc.WithUser(options.ServiceUser.Value);
+                if (options.ServiceEnvironment.HasValue) svc.WithEnvironment(options.ServiceEnvironment.Value.ToArray());
+            });
+        }
     }
 }

--- a/src/DotnetPackaging/PackageMetadata.cs
+++ b/src/DotnetPackaging/PackageMetadata.cs
@@ -68,4 +68,5 @@ public record PackageMetadata
     public Maybe<string> VcsBrowser { get; init; } = Maybe<string>.None;
     public Maybe<long> InstalledSize { get; init; } = Maybe<long>.None;
     public required DateTimeOffset ModificationTime { get; init; }
+    public Maybe<ServiceDefinition> Service { get; init; } = Maybe<ServiceDefinition>.None;
 }

--- a/src/DotnetPackaging/RestartPolicy.cs
+++ b/src/DotnetPackaging/RestartPolicy.cs
@@ -1,0 +1,11 @@
+namespace DotnetPackaging;
+
+public enum RestartPolicy
+{
+    No,
+    Always,
+    OnFailure,
+    OnAbnormal,
+    OnAbort,
+    OnWatchdog
+}

--- a/src/DotnetPackaging/ServiceDefinition.cs
+++ b/src/DotnetPackaging/ServiceDefinition.cs
@@ -1,0 +1,91 @@
+namespace DotnetPackaging;
+
+public class ServiceDefinition
+{
+    public Maybe<ServiceType> Type { get; private set; } = Maybe<ServiceType>.None;
+    public Maybe<RestartPolicy> Restart { get; private set; } = Maybe<RestartPolicy>.None;
+    public Maybe<int> RestartSec { get; private set; } = Maybe<int>.None;
+    public Maybe<string> User { get; private set; } = Maybe<string>.None;
+    public Maybe<string> Group { get; private set; } = Maybe<string>.None;
+    public Maybe<string> After { get; private set; } = Maybe<string>.None;
+    public Maybe<string> WantedBy { get; private set; } = Maybe<string>.None;
+    public Maybe<IEnumerable<string>> Environment { get; private set; } = Maybe<IEnumerable<string>>.None;
+
+    public ServiceDefinition WithType(ServiceType type)
+    {
+        Type = type;
+        return this;
+    }
+
+    public ServiceDefinition WithRestart(RestartPolicy restart)
+    {
+        Restart = restart;
+        return this;
+    }
+
+    public ServiceDefinition WithRestartSec(int restartSec)
+    {
+        if (restartSec < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(restartSec), "Must be non-negative");
+        }
+
+        RestartSec = restartSec;
+        return this;
+    }
+
+    public ServiceDefinition WithUser(string user)
+    {
+        if (string.IsNullOrWhiteSpace(user))
+        {
+            throw new ArgumentException("Can't be null or empty", nameof(user));
+        }
+
+        User = user;
+        return this;
+    }
+
+    public ServiceDefinition WithGroup(string group)
+    {
+        if (string.IsNullOrWhiteSpace(group))
+        {
+            throw new ArgumentException("Can't be null or empty", nameof(group));
+        }
+
+        Group = group;
+        return this;
+    }
+
+    public ServiceDefinition WithAfter(string after)
+    {
+        if (string.IsNullOrWhiteSpace(after))
+        {
+            throw new ArgumentException("Can't be null or empty", nameof(after));
+        }
+
+        After = after;
+        return this;
+    }
+
+    public ServiceDefinition WithWantedBy(string wantedBy)
+    {
+        if (string.IsNullOrWhiteSpace(wantedBy))
+        {
+            throw new ArgumentException("Can't be null or empty", nameof(wantedBy));
+        }
+
+        WantedBy = wantedBy;
+        return this;
+    }
+
+    public ServiceDefinition WithEnvironment(params string[] variables)
+    {
+        if (variables == null || variables.Length == 0)
+        {
+            throw new ArgumentException("At least one variable is required", nameof(variables));
+        }
+
+        Environment = Maybe<IEnumerable<string>>.From(variables);
+        return this;
+    }
+}

--- a/src/DotnetPackaging/ServiceType.cs
+++ b/src/DotnetPackaging/ServiceType.cs
@@ -1,0 +1,10 @@
+namespace DotnetPackaging;
+
+public enum ServiceType
+{
+    Simple,
+    Notify,
+    Forking,
+    OneShot,
+    Idle
+}

--- a/src/DotnetPackaging/TextTemplates.cs
+++ b/src/DotnetPackaging/TextTemplates.cs
@@ -35,4 +35,113 @@ public static class TextTemplates
     {
         return AppStreamXmlGenerator.GenerateXml(packageMetadata).ToString();
     }
+
+    public static string SystemdUnitFile(string executablePath, string workingDirectory, PackageMetadata metadata)
+    {
+        var svc = metadata.Service.GetValueOrDefault(new ServiceDefinition());
+        var type = svc.Type.GetValueOrDefault(ServiceType.Simple);
+        var restart = svc.Restart.GetValueOrDefault(RestartPolicy.OnFailure);
+        var restartSec = svc.RestartSec.GetValueOrDefault(10);
+        var after = svc.After.GetValueOrDefault("network-online.target");
+        var wantedBy = svc.WantedBy.GetValueOrDefault("multi-user.target");
+        var description = metadata.Description.GetValueOrDefault(metadata.Name);
+
+        var lines = new List<string>
+        {
+            "[Unit]",
+            $"Description={description}",
+            $"After={after}",
+            $"Wants={after}",
+            "",
+            "[Service]",
+            $"Type={FormatServiceType(type)}",
+            $"ExecStart={executablePath}",
+            $"WorkingDirectory={workingDirectory}",
+            $"Restart={FormatRestartPolicy(restart)}",
+            $"RestartSec={restartSec}",
+            $"SyslogIdentifier={metadata.Package}",
+        };
+
+        if (svc.User.HasValue)
+        {
+            lines.Add($"User={svc.User.Value}");
+        }
+
+        if (svc.Group.HasValue)
+        {
+            lines.Add($"Group={svc.Group.Value}");
+        }
+
+        if (svc.Environment.HasValue)
+        {
+            foreach (var env in svc.Environment.Value)
+            {
+                lines.Add($"Environment={env}");
+            }
+        }
+
+        lines.Add("");
+        lines.Add("[Install]");
+        lines.Add($"WantedBy={wantedBy}");
+        lines.Add("");
+
+        return string.Join("\n", lines);
+    }
+
+    public static string PostInstScript(string package)
+    {
+        return $"""
+               #!/bin/sh
+               set -e
+               if [ "$1" = "configure" ]; then
+                   systemctl daemon-reload
+                   systemctl enable {package}.service
+                   systemctl start {package}.service
+               fi
+               """;
+    }
+
+    public static string PreRmScript(string package)
+    {
+        return $"""
+               #!/bin/sh
+               set -e
+               if [ "$1" = "remove" ] || [ "$1" = "upgrade" ]; then
+                   systemctl stop {package}.service || true
+                   systemctl disable {package}.service || true
+               fi
+               """;
+    }
+
+    public static string PostRmScript(string package)
+    {
+        return $"""
+               #!/bin/sh
+               set -e
+               if [ "$1" = "purge" ]; then
+                   systemctl daemon-reload
+               fi
+               """;
+    }
+
+    private static string FormatServiceType(ServiceType type) => type switch
+    {
+        ServiceType.Simple => "simple",
+        ServiceType.Notify => "notify",
+        ServiceType.Forking => "forking",
+        ServiceType.OneShot => "oneshot",
+        ServiceType.Idle => "idle",
+        _ => "simple"
+    };
+
+    private static string FormatRestartPolicy(RestartPolicy policy) => policy switch
+    {
+        RestartPolicy.No => "no",
+        RestartPolicy.Always => "always",
+        RestartPolicy.OnFailure => "on-failure",
+        RestartPolicy.OnAbnormal => "on-abnormal",
+        RestartPolicy.OnAbort => "on-abort",
+        RestartPolicy.OnWatchdog => "on-watchdog",
+        _ => "on-failure"
+    };
 }

--- a/test/DotnetPackaging.Deb.Tests/DebServicePackageTests.cs
+++ b/test/DotnetPackaging.Deb.Tests/DebServicePackageTests.cs
@@ -1,0 +1,241 @@
+using CSharpFunctionalExtensions;
+using DotnetPackaging;
+using System.IO.Abstractions;
+using Zafiro.DivineBytes;
+using Zafiro.DivineBytes.System.IO;
+using IOPath = System.IO.Path;
+
+namespace DotnetPackaging.Deb.Tests;
+
+[Collection("deb-service-package")]
+public class DebServicePackageTests
+{
+    private readonly DebServicePackageFixture fixture;
+
+    public DebServicePackageTests(DebServicePackageFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public void Ar_archive_contains_required_members()
+    {
+        fixture.ArEntries.Should().HaveCount(3);
+        fixture.ArEntries.Select(e => e.Name).Should().ContainInOrder("debian-binary", "control.tar", "data.tar");
+    }
+
+    [Fact]
+    public void Control_tar_contains_maintainer_scripts()
+    {
+        var controlEntry = fixture.GetEntry("control.tar");
+        var controlTar = TarArchiveReader.ReadEntries(controlEntry.Data);
+        var names = controlTar.Select(e => e.Name).ToList();
+
+        names.Should().Contain("control");
+        names.Should().Contain("postinst");
+        names.Should().Contain("prerm");
+        names.Should().Contain("postrm");
+    }
+
+    [Fact]
+    public void Postinst_enables_and_starts_service()
+    {
+        var controlEntry = fixture.GetEntry("control.tar");
+        var controlTar = TarArchiveReader.ReadEntries(controlEntry.Data);
+        var postinst = controlTar.Single(e => e.Name == "postinst");
+        var text = Encoding.ASCII.GetString(postinst.Data);
+
+        text.Should().Contain("systemctl daemon-reload");
+        text.Should().Contain("systemctl enable my-service.service");
+        text.Should().Contain("systemctl start my-service.service");
+        text.Should().Contain("configure");
+    }
+
+    [Fact]
+    public void Prerm_stops_and_disables_service()
+    {
+        var controlEntry = fixture.GetEntry("control.tar");
+        var controlTar = TarArchiveReader.ReadEntries(controlEntry.Data);
+        var prerm = controlTar.Single(e => e.Name == "prerm");
+        var text = Encoding.ASCII.GetString(prerm.Data);
+
+        text.Should().Contain("systemctl stop my-service.service");
+        text.Should().Contain("systemctl disable my-service.service");
+    }
+
+    [Fact]
+    public void Postrm_reloads_daemon_on_purge()
+    {
+        var controlEntry = fixture.GetEntry("control.tar");
+        var controlTar = TarArchiveReader.ReadEntries(controlEntry.Data);
+        var postrm = controlTar.Single(e => e.Name == "postrm");
+        var text = Encoding.ASCII.GetString(postrm.Data);
+
+        text.Should().Contain("systemctl daemon-reload");
+        text.Should().Contain("purge");
+    }
+
+    [Fact]
+    public void Data_tar_contains_systemd_unit_file()
+    {
+        var dataEntry = fixture.GetEntry("data.tar");
+        var dataTar = TarArchiveReader.ReadEntries(dataEntry.Data);
+
+        dataTar.Select(e => e.Name).Should().Contain("lib/systemd/system/my-service.service");
+    }
+
+    [Fact]
+    public void Systemd_unit_file_has_correct_content()
+    {
+        var dataEntry = fixture.GetEntry("data.tar");
+        var dataTar = TarArchiveReader.ReadEntries(dataEntry.Data);
+        var unitFile = dataTar.Single(e => e.Name == "lib/systemd/system/my-service.service");
+        var text = Encoding.ASCII.GetString(unitFile.Data);
+
+        text.Should().Contain("[Unit]");
+        text.Should().Contain("[Service]");
+        text.Should().Contain("[Install]");
+        text.Should().Contain("Type=simple");
+        text.Should().Contain("ExecStart=/opt/my-service/my-service");
+        text.Should().Contain("WorkingDirectory=/opt/my-service");
+        text.Should().Contain("Restart=on-failure");
+        text.Should().Contain("WantedBy=multi-user.target");
+        text.Should().Contain("SyslogIdentifier=my-service");
+    }
+
+    [Fact]
+    public void Data_tar_does_not_contain_desktop_file()
+    {
+        var dataEntry = fixture.GetEntry("data.tar");
+        var dataTar = TarArchiveReader.ReadEntries(dataEntry.Data);
+
+        dataTar.Select(e => e.Name).Should().NotContain(n => n.Contains(".desktop"));
+    }
+
+    [Fact]
+    public void Data_tar_still_contains_usr_bin_wrapper()
+    {
+        var dataEntry = fixture.GetEntry("data.tar");
+        var dataTar = TarArchiveReader.ReadEntries(dataEntry.Data);
+
+        dataTar.Select(e => e.Name).Should().Contain("usr/bin/my-service");
+
+        var wrapper = dataTar.Single(e => e.Name == "usr/bin/my-service");
+        var text = Encoding.ASCII.GetString(wrapper.Data);
+        text.Should().StartWith("#!/usr/bin/env sh");
+        text.Should().Contain("/opt/my-service/my-service");
+    }
+
+    [Fact]
+    public void Data_tar_contains_application_files()
+    {
+        var dataEntry = fixture.GetEntry("data.tar");
+        var dataTar = TarArchiveReader.ReadEntries(dataEntry.Data);
+
+        dataTar.Select(e => e.Name).Should().Contain("opt/my-service/my-service");
+        dataTar.Select(e => e.Name).Should().Contain("opt/my-service/appsettings.json");
+    }
+
+    [Fact]
+    public void Maintainer_scripts_are_executable()
+    {
+        var controlEntry = fixture.GetEntry("control.tar");
+        var controlTar = TarArchiveReader.ReadEntries(controlEntry.Data);
+
+        foreach (var scriptName in new[] { "postinst", "prerm", "postrm" })
+        {
+            var script = controlTar.Single(e => e.Name == scriptName);
+            // Mode should be 755 (rwxr-xr-x)
+            script.Mode.Should().HaveFlag(UnixFileMode.UserExecute, $"{scriptName} should be executable");
+        }
+    }
+}
+
+[CollectionDefinition("deb-service-package")]
+public class DebServicePackageCollection : ICollectionFixture<DebServicePackageFixture>
+{
+}
+
+public sealed class DebServicePackageFixture : IAsyncLifetime
+{
+    private readonly string workingDirectory = IOPath.Combine(IOPath.GetTempPath(), $"deb-svc-tests-{Guid.NewGuid():N}");
+    private readonly string sourceDirectory;
+    private readonly string outputFilePath;
+
+    public DebServicePackageFixture()
+    {
+        sourceDirectory = IOPath.Combine(workingDirectory, "publish");
+        outputFilePath = IOPath.Combine(workingDirectory, "my-service.deb");
+    }
+
+    public IReadOnlyList<ArEntry> ArEntries { get; private set; } = Array.Empty<ArEntry>();
+    public byte[] PackageBytes { get; private set; } = Array.Empty<byte>();
+    public ArEntry GetEntry(string name) => ArEntries.Single(e => string.Equals(e.Name, name, StringComparison.Ordinal));
+
+    public async Task InitializeAsync()
+    {
+        Directory.CreateDirectory(sourceDirectory);
+        await WritePayloadAsync(sourceDirectory);
+
+        var fs = new FileSystem();
+        var dirInfo = new DirectoryInfo(sourceDirectory);
+        var container = new DirectoryContainer(new DirectoryInfoWrapper(fs, dirInfo)).AsRoot();
+
+        var options = new FromDirectoryOptions();
+        options.WithName("My Service");
+        options.WithVersion("2.0.0");
+        options.WithDescription("A test background service");
+        options.WithExecutableName("my-service");
+        options.WithService();
+
+        var result = await new DebPackager().Pack(container, options);
+
+        if (result.IsFailure)
+        {
+            throw new InvalidOperationException($"Building service .deb failed: {result.Error}");
+        }
+
+        using var memStream = new MemoryStream();
+        var writeResult = await result.Value.WriteTo(memStream);
+        if (writeResult.IsFailure)
+        {
+            throw new InvalidOperationException($"Writing .deb failed: {writeResult.Error}");
+        }
+
+        PackageBytes = memStream.ToArray();
+        ArEntries = ArArchiveReader.Read(PackageBytes);
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(workingDirectory))
+        {
+            try { Directory.Delete(workingDirectory, true); }
+            catch { }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static async Task WritePayloadAsync(string directory)
+    {
+        var executablePath = IOPath.Combine(directory, "my-service");
+        await File.WriteAllBytesAsync(executablePath, CreateElfStub());
+
+        await File.WriteAllTextAsync(IOPath.Combine(directory, "appsettings.json"), "{ \"Logging\": { \"LogLevel\": { \"Default\": \"Information\" } } }");
+    }
+
+    private static byte[] CreateElfStub()
+    {
+        var bytes = new byte[64];
+        bytes[0] = 0x7F;
+        bytes[1] = (byte)'E';
+        bytes[2] = (byte)'L';
+        bytes[3] = (byte)'F';
+        bytes[4] = 2;
+        bytes[5] = 1;
+        BitConverter.GetBytes((ushort)2).CopyTo(bytes, 16);
+        BitConverter.GetBytes((ushort)0x3E).CopyTo(bytes, 18);
+        return bytes;
+    }
+}


### PR DESCRIPTION
## Summary

Add `--service` flag to both `deb` and `deb from-project` commands that generates a complete systemd service setup: unit file, maintainer scripts, and automatic enable/start on install.

## For the .NET developer

```bash
# From a project (publish + package in one step)
dotnet deb from-project --project MyApi.csproj --output myapi.deb --service

# From a pre-published folder
dotnet deb --directory ./publish --output myapi.deb --service --application-name myapi
```

That's it. One flag. The generated .deb will:
- Install a systemd unit file at `/lib/systemd/system/{package}.service`
- `systemctl daemon-reload` + `enable` + `start` on install
- `stop` + `disable` on removal
- Clean up on purge
- Keep the `/usr/bin/` launcher wrapper (so the app is also runnable from CLI)
- **Not** generate a `.desktop` file (services don't need one)

### Additional options (all optional)

| Flag | Default | Description |
|------|---------|-------------|
| `--service-type` | `simple` | `simple`, `notify`, `forking`, `oneshot` |
| `--service-restart` | `on-failure` | `always`, `on-failure`, `no`, etc. |
| `--service-user` | *(none)* | Run as specific user |
| `--service-environment` | *(none)* | Env vars, e.g. `DOTNET_ENVIRONMENT=Production` |

## Refactoring: eliminate option duplication

Every `from-project` subcommand was redeclaring the same ~15 metadata options that `CommandFactory` already creates. This PR extracts:

- **`MetadataOptionSet`** — single source of truth for the 15 metadata CLI options
- **`ProjectOptionSet`** — single source of truth for the 7 project CLI options + arch auto-detect

**Net result: -335 lines** across all 6 format commands (deb, rpm, appimage, dmg, exe, msix).

## Tests

- 11 new tests covering: AR structure, control.tar scripts (content + permissions), data.tar `.service` file, no `.desktop`, `/usr/bin` wrapper preserved, application files present
- All 18 deb tests pass (7 original + 11 new)
- All 7 appimage tests pass (regression check after refactor)