### PR TITLE
feat: add from-directory subcommand, deprecate base --directory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,21 +123,28 @@ dotnet tool install --global DotnetPackaging.Tool
 ```
 
 ### Commands
-- `dotnetpackager appimage` – build an `.AppImage` file directly from a publish directory.
-- `dotnetpackager appimage appdir` – generate an AppDir folder structure for inspection/customisation.
-- `dotnetpackager appimage from-appdir` – package an existing AppDir into an AppImage.
-- `dotnetpackager deb` – build a Debian/Ubuntu `.deb` out of a publish directory (and `deb from-project` to publish + package in one step). Supports `--service` to install as a systemd daemon.
-- `dotnetpackager rpm` – build an RPM from a publish directory (`rpm from-project` also available) without owning system dirs.
-- `dotnetpackager msix` – experimental MSIX packing from a directory (`msix from-project` when you want it published for you).
-- `dotnetpackager dmg` – experimental macOS `.dmg` builder from a publish directory (`dmg from-project` to publish + package).
-- `dotnetpackager exe` – preview Windows self-extracting installer builder; supports `exe from-project` and stub auto-download.
+
+Every format command offers two subcommands:
+- **`from-directory`** – package from a pre-published directory (the output of `dotnet publish`).
+- **`from-project`** – publish a .NET project and package in one step.
+
+> **Deprecation notice:** invoking the base command directly with `--directory` (e.g. `dotnetpackager deb --directory`) still works for backward compatibility but is deprecated. Use `deb from-directory` instead. A future release will remove the deprecated form.
+
+| Format | From directory | From project | Extra subcommands |
+|---|---|---|---|
+| **appimage** | `appimage from-directory` | `appimage from-project` | `appdir`, `from-appdir` |
+| **deb** | `deb from-directory` | `deb from-project` | — |
+| **rpm** | `rpm from-directory` | `rpm from-project` | — |
+| **dmg** | `dmg from-directory` | `dmg from-project` | `verify` |
+| **exe** | `exe from-directory` | `exe from-project` | — |
+| **msix** | `msix from-directory` | `msix from-project` | — |
 
 Run `dotnetpackager <command> --help` to see the full list of shared options (`--application-name`, `--comment`, `--homepage`, `--keywords`, `--icon`, `--is-terminal`, etc.).
 
 ### Examples
-Build an AppImage in one go:
+Build an AppImage from a published directory:
 ```bash
-dotnetpackager appimage \
+dotnetpackager appimage from-directory \
   --directory ./bin/Release/net10.0/linux-x64/publish \
   --output ./artifacts/MyApp.appimage \
   --application-name "My App" \
@@ -160,7 +167,7 @@ dotnetpackager appimage from-appdir \
 
 Produce a Debian package with a custom name and version:
 ```bash
-dotnetpackager deb \
+dotnetpackager deb from-directory \
   --directory ./bin/Release/net10.0/linux-x64/publish \
   --output ./artifacts/MyApp_1.0.0_amd64.deb \
   --application-name "My App" \
@@ -195,7 +202,7 @@ dotnetpackager deb from-project \
 
 The `--service` flag also works from a pre-published directory:
 ```bash
-dotnetpackager deb \
+dotnetpackager deb from-directory \
   --directory ./bin/Release/net10.0/linux-x64/publish \
   --output ./artifacts/myapi.deb \
   --application-name myapi \

--- a/src/DotnetPackaging.Tool/Commands/AppImageCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/AppImageCommand.cs
@@ -16,7 +16,7 @@ public static class AppImageCommand
 
     public static Command GetCommand()
     {
-        var command = CommandFactory.CreateCommand(
+        var commands = CommandFactory.CreateCommand(
             "appimage",
             "AppImage package",
             ".AppImage",
@@ -26,9 +26,9 @@ public static class AppImageCommand
             null,
             "pack-appimage");
 
-        AddAppImageSubcommands(command);
-        AddFromProjectSubcommand(command);
-        return command;
+        AddAppImageSubcommands(commands.Root);
+        AddFromProjectSubcommand(commands.Root);
+        return commands.Root;
     }
 
     private static Task CreateAppImage(DirectoryInfo inputDir, FileInfo outputFile, Options options, ILogger logger)

--- a/src/DotnetPackaging.Tool/Commands/CommandFactory.cs
+++ b/src/DotnetPackaging.Tool/Commands/CommandFactory.cs
@@ -3,9 +3,11 @@ using Serilog;
 
 namespace DotnetPackaging.Tool.Commands;
 
+public record CommandSet(Command Root, Command FromDirectory);
+
 public static class CommandFactory
 {
-    public static Command CreateCommand(
+    public static CommandSet CreateCommand(
         string commandName,
         string friendlyName,
         string extension,
@@ -15,49 +17,85 @@ public static class CommandFactory
         Action<Options, ParseResult>? optionsPostProcessor = null,
         params string[] aliases)
     {
-        var buildDir = new Option<DirectoryInfo>("--directory")
+        var defaultDescription = description ??
+                                 $"Create a {friendlyName} from a directory with the published application contents. Everything is inferred. For .NET apps this is usually the 'publish' directory.";
+
+        // --- Base command (deprecated, backward-compatible) ---
+        var baseBuildDir = new Option<DirectoryInfo>("--directory")
         {
             Description = "Published application directory (for example: bin/Release/<tfm>/publish)",
             Required = true
         };
-        var outputFileOption = new Option<FileInfo>("--output")
+        var baseOutput = new Option<FileInfo>("--output")
         {
             Description = $"Destination path for the generated {extension} file",
             Required = true
         };
+        var baseMetadata = new MetadataOptionSet();
 
-        var metadata = new MetadataOptionSet();
-
-        var defaultDescription = description ??
-                                 $"Create a {friendlyName} from a directory with the published application contents. Everything is inferred. For .NET apps this is usually the 'publish' directory.";
-        var fromBuildDir = new Command(commandName, defaultDescription);
-
+        var rootCommand = new Command(commandName, defaultDescription);
         foreach (var alias in aliases)
         {
             if (!string.IsNullOrWhiteSpace(alias))
             {
-                fromBuildDir.Aliases.Add(alias);
+                rootCommand.Aliases.Add(alias);
             }
         }
 
-        fromBuildDir.Add(buildDir);
-        fromBuildDir.Add(outputFileOption);
-        metadata.AddTo(fromBuildDir);
+        rootCommand.Add(baseBuildDir);
+        rootCommand.Add(baseOutput);
+        baseMetadata.AddTo(rootCommand);
         if (defaultLayoutOption != null)
         {
-            fromBuildDir.Add(defaultLayoutOption);
+            rootCommand.Add(defaultLayoutOption);
         }
 
-        var options = metadata.CreateBinder(defaultLayoutOption);
+        var baseBinder = baseMetadata.CreateBinder(defaultLayoutOption);
 
-        fromBuildDir.SetAction(async parseResult =>
+        rootCommand.SetAction(async parseResult =>
         {
-            var directory = parseResult.GetValue(buildDir)!;
-            var output = parseResult.GetValue(outputFileOption)!;
-            var opts = options.Bind(parseResult);
+            Console.Error.WriteLine($"Warning: 'dotnetpackager {commandName} --directory' is deprecated and will be removed in a future version. Use 'dotnetpackager {commandName} from-directory' instead.");
+            var directory = parseResult.GetValue(baseBuildDir)!;
+            var output = parseResult.GetValue(baseOutput)!;
+            var opts = baseBinder.Bind(parseResult);
             optionsPostProcessor?.Invoke(opts, parseResult);
             await ExecutionWrapper.ExecuteWithLogging(commandName, output.FullName, logger => handler(directory, output, opts, logger));
         });
-        return fromBuildDir;
+
+        // --- from-directory subcommand (canonical path) ---
+        var fdBuildDir = new Option<DirectoryInfo>("--directory")
+        {
+            Description = "Published application directory (for example: bin/Release/<tfm>/publish)",
+            Required = true
+        };
+        var fdOutput = new Option<FileInfo>("--output")
+        {
+            Description = $"Destination path for the generated {extension} file",
+            Required = true
+        };
+        var fdMetadata = new MetadataOptionSet();
+
+        var fromDirectoryCommand = new Command("from-directory", $"Create a {friendlyName} from a published application directory.");
+        fromDirectoryCommand.Add(fdBuildDir);
+        fromDirectoryCommand.Add(fdOutput);
+        fdMetadata.AddTo(fromDirectoryCommand);
+        if (defaultLayoutOption != null)
+        {
+            fromDirectoryCommand.Add(defaultLayoutOption);
+        }
+
+        var fdBinder = fdMetadata.CreateBinder(defaultLayoutOption);
+
+        fromDirectoryCommand.SetAction(async parseResult =>
+        {
+            var directory = parseResult.GetValue(fdBuildDir)!;
+            var output = parseResult.GetValue(fdOutput)!;
+            var opts = fdBinder.Bind(parseResult);
+            optionsPostProcessor?.Invoke(opts, parseResult);
+            await ExecutionWrapper.ExecuteWithLogging(commandName, output.FullName, logger => handler(directory, output, opts, logger));
+        });
+
+        rootCommand.Add(fromDirectoryCommand);
+        return new CommandSet(rootCommand, fromDirectoryCommand);
     }
 }

--- a/src/DotnetPackaging.Tool/Commands/DebCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/DebCommand.cs
@@ -19,7 +19,7 @@ public static class DebCommand
         var serviceUserOption = new Option<string?>("--service-user") { Description = "User to run the service as" };
         var serviceEnvironmentOption = new Option<IEnumerable<string>>("--service-environment") { Description = "Environment variables (e.g., DOTNET_ENVIRONMENT=Production)", Arity = ArgumentArity.ZeroOrMore, AllowMultipleArgumentsPerToken = true };
 
-        var command = CommandFactory.CreateCommand(
+        var commands = CommandFactory.CreateCommand(
             "deb",
             "Debian package",
             ".deb",
@@ -30,14 +30,20 @@ public static class DebCommand
             "pack-deb",
             "debian");
 
-        command.Add(serviceOption);
-        command.Add(serviceTypeOption);
-        command.Add(serviceRestartOption);
-        command.Add(serviceUserOption);
-        command.Add(serviceEnvironmentOption);
+        commands.Root.Add(serviceOption);
+        commands.Root.Add(serviceTypeOption);
+        commands.Root.Add(serviceRestartOption);
+        commands.Root.Add(serviceUserOption);
+        commands.Root.Add(serviceEnvironmentOption);
 
-        AddFromProjectSubcommand(command, serviceOption, serviceTypeOption, serviceRestartOption, serviceUserOption, serviceEnvironmentOption);
-        return command;
+        commands.FromDirectory.Add(serviceOption);
+        commands.FromDirectory.Add(serviceTypeOption);
+        commands.FromDirectory.Add(serviceRestartOption);
+        commands.FromDirectory.Add(serviceUserOption);
+        commands.FromDirectory.Add(serviceEnvironmentOption);
+
+        AddFromProjectSubcommand(commands.Root, serviceOption, serviceTypeOption, serviceRestartOption, serviceUserOption, serviceEnvironmentOption);
+        return commands.Root;
     }
 
     private static void ApplyServiceOptions(Options opts, ParseResult parseResult, Option<bool> serviceOption, Option<string?> serviceTypeOption, Option<string?> serviceRestartOption, Option<string?> serviceUserOption, Option<IEnumerable<string>> serviceEnvironmentOption)

--- a/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
@@ -24,7 +24,7 @@ public static class DmgCommand
         };
         defaultLayoutOption.DefaultValueFactory = _ => true;
 
-        var dmgCommand = CommandFactory.CreateCommand(
+        var commands = CommandFactory.CreateCommand(
             "dmg",
             "macOS disk image",
             ".dmg",
@@ -34,7 +34,7 @@ public static class DmgCommand
             null,
             "pack-dmg");
 
-        AddDmgFromProjectSubcommand(dmgCommand);
+        AddDmgFromProjectSubcommand(commands.Root);
 
         // dmg verify subcommand
         var verifyFileOption = new Option<FileInfo>("--file")
@@ -63,9 +63,9 @@ public static class DmgCommand
                 }
             });
         });
-        dmgCommand.Add(verifyCmd);
+        commands.Root.Add(verifyCmd);
 
-        return dmgCommand;
+        return commands.Root;
     }
 
     private static Task CreateDmg(DirectoryInfo inputDir, FileInfo outputFile, Options options, ILogger logger)

--- a/src/DotnetPackaging.Tool/Commands/ExeCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/ExeCommand.cs
@@ -67,6 +67,7 @@ public static class ExeCommand
 
         exeCommand.SetAction(async parseResult =>
         {
+            Console.Error.WriteLine("Warning: 'dotnetpackager exe --directory' is deprecated and will be removed in a future version. Use 'dotnetpackager exe from-directory' instead.");
             var inDir = parseResult.GetValue(exeInputDir)!;
             var outFile = parseResult.GetValue(exeOutput)!;
             var stub = parseResult.GetValue(stubPath);
@@ -124,6 +125,103 @@ public static class ExeCommand
                 logger.Information("{OutputFile}", outFile.FullName);
             });
         });
+
+        // exe from-directory (canonical path)
+        var fdInputDir = new Option<DirectoryInfo>("--directory")
+        {
+            Description = "The input directory (publish output)",
+            Required = true
+        };
+        var fdOutput = new Option<FileInfo>("--output")
+        {
+            Description = "Output installer .exe",
+            Required = true
+        };
+        var fdStub = new Option<FileInfo>("--stub")
+        {
+            Description = "Path to the prebuilt stub (WinExe) to concatenate (optional if repo layout is present)"
+        };
+        var fdSetupLogo = new Option<FileInfo?>("--setup-logo")
+        {
+            Description = "Path to a logo image displayed by the installer and uninstaller wizards"
+        };
+        var fdArch = new Option<string?>("--arch")
+        {
+            Description = "Target architecture for the stub (x64, arm64)"
+        };
+        var fdMetadata = new MetadataOptionSet();
+        var fdBinder = fdMetadata.CreateBinder();
+
+        var fromDirectory = new Command("from-directory") { Description = "Create a Windows self-extracting installer (.exe) from a published application directory." };
+        fromDirectory.Add(fdInputDir);
+        fromDirectory.Add(fdOutput);
+        fromDirectory.Add(fdStub);
+        fromDirectory.Add(fdSetupLogo);
+        fromDirectory.Add(exVendor);
+        fromDirectory.Add(fdArch);
+        fdMetadata.AddTo(fromDirectory);
+
+        fromDirectory.SetAction(async parseResult =>
+        {
+            var inDir = parseResult.GetValue(fdInputDir)!;
+            var outFile = parseResult.GetValue(fdOutput)!;
+            var stub = parseResult.GetValue(fdStub);
+            var logo = parseResult.GetValue(fdSetupLogo);
+            var opt = fdBinder.Bind(parseResult);
+            var vendorOpt = parseResult.GetValue(exVendor);
+            var archOpt = parseResult.GetValue(fdArch);
+
+            await ExecutionWrapper.ExecuteWithLogging("exe", outFile.FullName, async logger =>
+            {
+                var ridResult = RidUtils.ResolveWindowsRid(archOpt, "EXE packaging");
+                if (ridResult.IsFailure)
+                {
+                    logger.Error("Invalid architecture: {Error}", ridResult.Error);
+                    Environment.ExitCode = 1;
+                    return;
+                }
+
+                var containerResult = new DirectoryContainer(new DirectoryInfoWrapper(new FileSystem(), inDir)).AsRoot();
+
+                var stubBytes = stub != null
+                    ? (IByteSource)ByteSource.FromStreamFactory(() => File.OpenRead(stub.FullName))
+                    : null;
+
+                var logoBytes = logo != null
+                    ? (IByteSource)ByteSource.FromStreamFactory(() => File.OpenRead(logo.FullName))
+                    : null;
+
+                var packager = new ExePackager(logger: logger);
+                var exeMetadata = new ExePackagerMetadata
+                {
+                    Options = opt,
+                    Vendor = Maybe.From(vendorOpt),
+                    RuntimeIdentifier = Maybe.From(ridResult.Value),
+                    Stub = stubBytes == null ? Maybe<IByteSource>.None : Maybe.From(stubBytes),
+                    SetupLogo = logoBytes == null ? Maybe<IByteSource>.None : Maybe.From(logoBytes),
+                    OutputName = Maybe.From(outFile.Name)
+                };
+
+                var result = await packager.Pack(containerResult, exeMetadata);
+                if (result.IsFailure)
+                {
+                    logger.Error("EXE packaging failed: {Error}", result.Error);
+                    Environment.ExitCode = 1;
+                    return;
+                }
+
+                var writeResult = await result.Value.WriteTo(outFile.FullName);
+                if (writeResult.IsFailure)
+                {
+                    logger.Error("Failed to persist installer: {Error}", writeResult.Error);
+                    Environment.ExitCode = 1;
+                    return;
+                }
+                logger.Information("{OutputFile}", outFile.FullName);
+            });
+        });
+
+        exeCommand.Add(fromDirectory);
 
         // exe from-project
         var project = new ProjectOptionSet(".exe");

--- a/src/DotnetPackaging.Tool/Commands/MsixCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/MsixCommand.cs
@@ -21,7 +21,8 @@ public static class MsixCommand
     {
         var inputDir = new Option<DirectoryInfo>("--directory") { Description = "The input directory (publish output)", Required = true };
         var outputFile = new Option<FileInfo>("--output") { Description = "Output .msix file", Required = true };
-        var packCmd = new Command("pack") { Description = "Create an MSIX from a directory (expects AppxManifest.xml in the tree or pre-baked metadata). Experimental." };
+        var packCmd = new Command("from-directory") { Description = "Create an MSIX from a directory (expects AppxManifest.xml in the tree or pre-baked metadata). Experimental." };
+        packCmd.Aliases.Add("pack");
         packCmd.Add(inputDir);
         packCmd.Add(outputFile);
         packCmd.SetAction(async parseResult =>

--- a/src/DotnetPackaging.Tool/Commands/RpmCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/RpmCommand.cs
@@ -12,7 +12,7 @@ public static class RpmCommand
 {
     public static Command GetCommand()
     {
-        var command = CommandFactory.CreateCommand(
+        var commands = CommandFactory.CreateCommand(
             "rpm",
             "RPM package",
             ".rpm",
@@ -22,8 +22,8 @@ public static class RpmCommand
             null,
             "pack-rpm");
 
-        AddFromProjectSubcommand(command);
-        return command;
+        AddFromProjectSubcommand(commands.Root);
+        return commands.Root;
     }
 
     private static Task CreateRpm(DirectoryInfo inputDir, FileInfo outputFile, Options options, ILogger logger)
@@ -41,8 +41,7 @@ public static class RpmCommand
             .WriteResult();
     }
 
-    private static void AddFromProjectSubcommand(Command rpmCommand)
-    {
+    private static void AddFromProjectSubcommand(Command rpmCommand)    {
         var metadata = new MetadataOptionSet();
         var project = new ProjectOptionSet(".rpm");
 


### PR DESCRIPTION
## Summary

Adds a `from-directory` subcommand to every format, making the CLI symmetric:

```
dotnetpackager <format> from-directory --directory ... --output ...
dotnetpackager <format> from-project   --project ...  --output ...
```

The old form (`dotnetpackager <format> --directory ...`) still works but prints a deprecation warning. It will be removed in a future major version.

## What changed

| Format | `from-directory` | Deprecation on base | Notes |
|---|---|---|---|
| deb | ✅ via CommandFactory | ✅ | Service options on all 3 paths |
| rpm | ✅ via CommandFactory | ✅ | — |
| appimage | ✅ via CommandFactory | ✅ | `appdir`/`from-appdir` unchanged |
| dmg | ✅ via CommandFactory | ✅ | `verify` unchanged |
| exe | ✅ manual | ✅ | — |
| msix | ✅ renamed `pack` → `from-directory` | N/A (was already subcommand-only) | `pack` kept as alias |

### Implementation

- `CommandFactory.CreateCommand()` now returns `CommandSet(Root, FromDirectory)` — creates both the deprecated base command and the canonical `from-directory` subcommand internally
- Base command handler prepends a deprecation warning to stderr
- `from-directory` has identical options and behavior, no warning
- For **exe** (doesn't use CommandFactory): manual `from-directory` + deprecation
- For **msix**: `pack` renamed to `from-directory` with `pack` as backward-compatible alias

### Tests
- 18/18 deb tests pass
- 7/7 appimage tests pass
- No behavioral changes — only CLI routing and deprecation message