### PR TITLE
fix: suppress misleading icon autodetection warning when --icon is provided

### DIFF
--- a/src/DotnetPackaging/BuildUtils.cs
+++ b/src/DotnetPackaging/BuildUtils.cs
@@ -44,7 +44,7 @@ public static class BuildUtils
         {
             log.Information("Found icon in resource {Resource}", RelativePath(iconPlan.Svg.Value));
         }
-        else
+        else if (setup.Icon.HasNoValue)
         {
             log.Warning("Icon autodetection: Could not find any icon in '{Label}'. Looked for candidates such as icon.svg, icon.png, icon-256.png", label);
         }


### PR DESCRIPTION
## Problem

When using `--icon` to provide an explicit icon path, the tool still emitted a misleading warning:

```
[WRN] Icon autodetection: Could not find any icon in 'container root'. Looked for candidates such as icon.svg, icon.png, icon-256.png
```

This confused users into thinking their icon was not being used, even though it was correctly installed in the package.

## Root cause

In `BuildUtils.CreateMetadata`, icon autodetection runs first and emits the warning unconditionally (line 49). The explicit `--icon` override is only applied afterwards (line 54-65). So the warning fires even when the user-provided icon will be used.

## Fix

The warning is now only shown when **both** autodetection fails **and** no explicit `--icon` was provided (`setup.Icon.HasNoValue`).

This is a one-line change: `else` → `else if (setup.Icon.HasNoValue)`.

## Impact

- No behavioral change to icon handling — explicit icons were always installed correctly.
- Only the spurious warning is suppressed.
- Affects all packaging commands (AppImage, DEB, RPM, Flatpak, DMG) that go through `BuildUtils.CreateMetadata`.