### PR TITLE
feat(exe): add managed Authenticode code signing for EXE packaging

### DIFF
--- a/src/DotnetPackaging.Exe/DotnetPackaging.Exe.csproj
+++ b/src/DotnetPackaging.Exe/DotnetPackaging.Exe.csproj
@@ -6,6 +6,9 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="DotnetPackaging.Exe.Tests" />
+  </ItemGroup>
   <Import Project="..\Common.props" />
   <ItemGroup>
     <PackageReference Include="NuGet.Versioning" />
@@ -13,6 +16,7 @@
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" />
     <PackageReference Include="Zafiro.DivineBytes" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DotnetPackaging.Exe/ExePackager.cs
+++ b/src/DotnetPackaging.Exe/ExePackager.cs
@@ -1,7 +1,9 @@
+using System.Security.Cryptography.X509Certificates;
 using CSharpFunctionalExtensions;
 using DotnetPackaging;
 using DotnetPackaging.Exe.Metadata;
 using DotnetPackaging.Publish;
+using DotnetPackaging.Signing;
 using Serilog;
 using System.Net.Http;
 using Zafiro.DivineBytes;
@@ -39,6 +41,23 @@ public sealed class ExePackager
             throw new ArgumentNullException(nameof(metadata));
         }
 
+        var certificateResult = ResolveCertificate(metadata);
+        if (certificateResult.IsFailure)
+        {
+            return Task.FromResult(Result.Failure<IByteSource>(certificateResult.Error));
+        }
+
+        var certificate = certificateResult.Value;
+
+        if (certificate.HasNoValue)
+        {
+            logger.Warning(
+                "⚠ No code signing certificate provided (--pfx). " +
+                "The resulting installer and application will be unsigned. " +
+                "Windows SmartScreen will likely block execution and show security warnings to users. " +
+                "For production distribution, provide a code signing certificate (--pfx <path>).");
+        }
+
         var rid = metadata.RuntimeIdentifier.GetValueOrDefault("win-x64");
         return GetRid(rid).Bind(async validRid =>
         {
@@ -60,10 +79,22 @@ public sealed class ExePackager
                 stub,
                 setupLogo,
                 metadata.ProjectName,
-                metadata.ProjectMetadata);
+                metadata.ProjectMetadata,
+                certificate);
 
             return result.Map(package => (IByteSource)package);
         });
+    }
+
+    private Result<Maybe<X509Certificate2>> ResolveCertificate(ExePackagerMetadata metadata)
+    {
+        if (metadata.PfxPath.HasNoValue)
+            return Result.Success(Maybe<X509Certificate2>.None);
+
+        return CertificateProvider.LoadFromPfx(
+                metadata.PfxPath.Value,
+                metadata.PfxPassword.GetValueOrDefault(string.Empty))
+            .Map(cert => Maybe<X509Certificate2>.From(cert));
     }
 
     private static Result<string> GetRid(string rid)

--- a/src/DotnetPackaging.Exe/ExePackagingService.cs
+++ b/src/DotnetPackaging.Exe/ExePackagingService.cs
@@ -2,6 +2,7 @@ using System;
 using CSharpFunctionalExtensions;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
 using DotnetPackaging;
 using DotnetPackaging.Exe.Metadata;
 using DotnetPackaging.Publish;
@@ -37,7 +38,8 @@ internal sealed class ExePackagingService
         string? vendor,
         string? runtimeIdentifier,
         IByteSource? stubFile,
-        IByteSource? setupLogo)
+        IByteSource? setupLogo,
+        Maybe<X509Certificate2> certificate = default)
     {
         var request = new ExePackagingRequest(
             publishDirectory,
@@ -48,7 +50,8 @@ internal sealed class ExePackagingService
             ToMaybe(stubFile),
             Maybe<string>.None,
             Maybe<ProjectMetadata>.None,
-            ToMaybe(setupLogo));
+            ToMaybe(setupLogo),
+            certificate);
 
         return Build(request).Bind(container => ToPackage(container, outputName, null));
     }
@@ -62,7 +65,8 @@ internal sealed class ExePackagingService
         IByteSource? stubFile,
         IByteSource? setupLogo,
         Maybe<string> projectName,
-        Maybe<ProjectMetadata> projectMetadata)
+        Maybe<ProjectMetadata> projectMetadata,
+        Maybe<X509Certificate2> certificate = default)
     {
         var request = new ExePackagingRequest(
             publishDirectory,
@@ -73,7 +77,8 @@ internal sealed class ExePackagingService
             ToMaybe(stubFile),
             projectName,
             projectMetadata,
-            ToMaybe(setupLogo));
+            ToMaybe(setupLogo),
+            certificate);
 
         return Build(request).Bind(container => ToPackage(container, outputName, null));
     }
@@ -89,7 +94,8 @@ internal sealed class ExePackagingService
         Options options,
         string? vendor,
         IByteSource? stubFile,
-        IByteSource? setupLogo)
+        IByteSource? setupLogo,
+        Maybe<X509Certificate2> certificate = default)
     {
         var publishRequest = new ProjectPublishRequest(projectFile.FullName)
         {
@@ -117,7 +123,8 @@ internal sealed class ExePackagingService
             ToMaybe(stubFile),
             Maybe<string>.From(Path.GetFileNameWithoutExtension(projectFile.Name)),
             projectMetadata,
-            ToMaybe(setupLogo));
+            ToMaybe(setupLogo),
+            certificate);
 
         var buildResult = await Build(request);
         if (buildResult.IsFailure)
@@ -153,9 +160,14 @@ internal sealed class ExePackagingService
             request.ProjectMetadata,
             request.SetupLogo);
 
+        if (request.Certificate.HasValue)
+        {
+            logger.Information("Code signing enabled. All PE files and the final installer will be signed.");
+        }
+
         async Task<Result<IContainer>> BuildWithStub(IByteSource stubBytes)
         {
-            var buildResult = await SimpleExePacker.Build(stubBytes, request.PublishDirectory, metadata, request.SetupLogo);
+            var buildResult = await SimpleExePacker.Build(stubBytes, request.PublishDirectory, metadata, request.SetupLogo, request.Certificate);
             if (buildResult.IsFailure)
             {
                 return Result.Failure<IContainer>(buildResult.Error);
@@ -365,5 +377,6 @@ internal sealed class ExePackagingService
         Maybe<IByteSource> Stub,
         Maybe<string> ProjectName,
         Maybe<ProjectMetadata> ProjectMetadata,
-        Maybe<IByteSource> SetupLogo);
+        Maybe<IByteSource> SetupLogo,
+        Maybe<X509Certificate2> Certificate);
 }

--- a/src/DotnetPackaging.Exe/Metadata/ExePackagerMetadata.cs
+++ b/src/DotnetPackaging.Exe/Metadata/ExePackagerMetadata.cs
@@ -14,4 +14,6 @@ public sealed class ExePackagerMetadata
     public Maybe<IByteSource> Stub { get; set; } = Maybe<IByteSource>.None;
     public Maybe<IByteSource> SetupLogo { get; set; } = Maybe<IByteSource>.None;
     public Maybe<ProjectMetadata> ProjectMetadata { get; set; } = Maybe<ProjectMetadata>.None;
+    public Maybe<string> PfxPath { get; set; } = Maybe<string>.None;
+    public Maybe<string> PfxPassword { get; set; } = Maybe<string>.None;
 }

--- a/src/DotnetPackaging.Exe/Signing/AuthenticodeSigner.cs
+++ b/src/DotnetPackaging.Exe/Signing/AuthenticodeSigner.cs
@@ -1,0 +1,87 @@
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Exe.Signing;
+
+internal static class AuthenticodeSigner
+{
+    private const string SpcIndirectDataOid = "1.3.6.1.4.1.311.2.1.4";
+    private const string SpcPeImageDataOid = "1.3.6.1.4.1.311.2.1.15";
+    private const string Sha256Oid = "2.16.840.1.101.3.4.2.1";
+    private const string SpcSpOpusInfoOid = "1.3.6.1.4.1.311.2.1.12";
+
+    public static Result<byte[]> CreateSignature(byte[] authenticodeHash, X509Certificate2 certificate)
+    {
+        return Result.Try(() =>
+        {
+            var spcContent = BuildSpcIndirectDataContent(authenticodeHash);
+            var contentInfo = new ContentInfo(new Oid(SpcIndirectDataOid), spcContent);
+
+            var signedCms = new SignedCms(contentInfo, false);
+            var signer = new CmsSigner(SubjectIdentifierType.IssuerAndSerialNumber, certificate)
+            {
+                DigestAlgorithm = new Oid(Sha256Oid),
+                IncludeOption = X509IncludeOption.WholeChain
+            };
+
+            signer.SignedAttributes.Add(BuildOpusInfoAttribute());
+
+            signedCms.ComputeSignature(signer);
+            return signedCms.Encode();
+        });
+    }
+
+    private static byte[] BuildSpcIndirectDataContent(byte[] hash)
+    {
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+
+        // SpcAttributeTypeAndOptionalValue
+        writer.PushSequence();
+        writer.WriteObjectIdentifier(SpcPeImageDataOid);
+
+        // SpcPeImageData
+        writer.PushSequence();
+        // flags: BIT STRING with includeResources bit set
+        writer.WriteBitString(new byte[] { 0x80 }, 6);
+        // file: [0] EXPLICIT SpcLink
+        var ctxExplicit0 = new Asn1Tag(TagClass.ContextSpecific, 0, true);
+        writer.PushSequence(ctxExplicit0);
+        // SpcLink choice [2] EXPLICIT = file
+        var ctxExplicit2 = new Asn1Tag(TagClass.ContextSpecific, 2, true);
+        writer.PushSequence(ctxExplicit2);
+        // SpcString choice [0] IMPLICIT BMPString (empty)
+        writer.WriteEncodedValue(new byte[] { 0x80, 0x00 });
+        writer.PopSequence(ctxExplicit2);
+        writer.PopSequence(ctxExplicit0);
+        writer.PopSequence(); // SpcPeImageData
+
+        writer.PopSequence(); // SpcAttributeTypeAndOptionalValue
+
+        // DigestInfo
+        writer.PushSequence();
+        writer.PushSequence();
+        writer.WriteObjectIdentifier(Sha256Oid);
+        writer.WriteNull();
+        writer.PopSequence();
+        writer.WriteOctetString(hash);
+        writer.PopSequence();
+
+        writer.PopSequence();
+        return writer.Encode();
+    }
+
+    private static CryptographicAttributeObject BuildOpusInfoAttribute()
+    {
+        var opusWriter = new AsnWriter(AsnEncodingRules.DER);
+        opusWriter.PushSequence();
+        opusWriter.PopSequence();
+
+        var oid = new Oid(SpcSpOpusInfoOid);
+        var collection = new AsnEncodedDataCollection(new AsnEncodedData(oid, opusWriter.Encode()));
+        return new CryptographicAttributeObject(oid, collection);
+    }
+}

--- a/src/DotnetPackaging.Exe/Signing/PeFile.cs
+++ b/src/DotnetPackaging.Exe/Signing/PeFile.cs
@@ -1,0 +1,104 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Exe.Signing;
+
+internal sealed class PeFile
+{
+    public int PeHeaderOffset { get; }
+    public bool IsPe32Plus { get; }
+    public int ChecksumOffset { get; }
+    public int CertTableDirEntryOffset { get; }
+    public int CertTableDataOffset { get; }
+    public int CertTableDataSize { get; }
+
+    private PeFile(int peHeaderOffset, bool isPe32Plus, int checksumOffset,
+        int certTableDirEntryOffset, int certTableDataOffset, int certTableDataSize)
+    {
+        PeHeaderOffset = peHeaderOffset;
+        IsPe32Plus = isPe32Plus;
+        ChecksumOffset = checksumOffset;
+        CertTableDirEntryOffset = certTableDirEntryOffset;
+        CertTableDataOffset = certTableDataOffset;
+        CertTableDataSize = certTableDataSize;
+    }
+
+    public static Result<PeFile> Parse(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 64)
+            return Result.Failure<PeFile>("File too small to be a valid PE");
+
+        if (data[0] != 0x4D || data[1] != 0x5A)
+            return Result.Failure<PeFile>("Not a valid PE file: missing MZ signature");
+
+        int peOffset = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(0x3C));
+        if (peOffset < 0 || peOffset + 24 > data.Length)
+            return Result.Failure<PeFile>("Invalid PE header offset");
+
+        if (data[peOffset] != 0x50 || data[peOffset + 1] != 0x45 ||
+            data[peOffset + 2] != 0x00 || data[peOffset + 3] != 0x00)
+            return Result.Failure<PeFile>("Not a valid PE file: missing PE\\0\\0 signature");
+
+        int optionalHeaderOffset = peOffset + 24;
+        if (optionalHeaderOffset + 2 > data.Length)
+            return Result.Failure<PeFile>("Invalid Optional Header");
+
+        ushort magic = BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(optionalHeaderOffset));
+        bool isPe32Plus = magic == 0x20B;
+
+        if (magic != 0x10B && magic != 0x20B)
+            return Result.Failure<PeFile>($"Unsupported PE format (magic=0x{magic:X4})");
+
+        int checksumOffset = optionalHeaderOffset + 64;
+
+        // Data directory offset differs between PE32 and PE32+
+        int dataDirectoryOffset = optionalHeaderOffset + (isPe32Plus ? 112 : 96);
+
+        // Certificate Table is the 5th data directory entry (index 4)
+        int certTableDirEntryOffset = dataDirectoryOffset + 4 * 8;
+
+        if (certTableDirEntryOffset + 8 > data.Length)
+            return Result.Failure<PeFile>("PE file too small: missing Certificate Table directory entry");
+
+        int certTableDataOffset = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(certTableDirEntryOffset));
+        int certTableDataSize = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(certTableDirEntryOffset + 4));
+
+        return new PeFile(peOffset, isPe32Plus, checksumOffset,
+            certTableDirEntryOffset, certTableDataOffset, certTableDataSize);
+    }
+
+    public static bool IsPeFile(ReadOnlySpan<byte> data)
+    {
+        if (data.Length < 64) return false;
+        if (data[0] != 0x4D || data[1] != 0x5A) return false;
+        int peOffset = BinaryPrimitives.ReadInt32LittleEndian(data.Slice(0x3C));
+        if (peOffset < 0 || peOffset + 4 > data.Length) return false;
+        return data[peOffset] == 0x50 && data[peOffset + 1] == 0x45 &&
+               data[peOffset + 2] == 0x00 && data[peOffset + 3] == 0x00;
+    }
+
+    public byte[] ComputeAuthenticodeHash(ReadOnlySpan<byte> data)
+    {
+        // Authenticode hash covers the entire file except:
+        // - The PE checksum field (4 bytes)
+        // - The Certificate Table directory entry (8 bytes)
+        // - Existing certificate data (from CertTableDataOffset to end)
+        int fileEnd = CertTableDataOffset > 0 ? CertTableDataOffset : data.Length;
+
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+        // Region 1: [0, ChecksumOffset)
+        hash.AppendData(data.Slice(0, ChecksumOffset));
+
+        // Region 2: [ChecksumOffset + 4, CertTableDirEntryOffset)
+        hash.AppendData(data.Slice(ChecksumOffset + 4, CertTableDirEntryOffset - (ChecksumOffset + 4)));
+
+        // Region 3: [CertTableDirEntryOffset + 8, fileEnd)
+        int region3Start = CertTableDirEntryOffset + 8;
+        if (fileEnd > region3Start)
+            hash.AppendData(data.Slice(region3Start, fileEnd - region3Start));
+
+        return hash.GetHashAndReset();
+    }
+}

--- a/src/DotnetPackaging.Exe/Signing/PeSignatureWriter.cs
+++ b/src/DotnetPackaging.Exe/Signing/PeSignatureWriter.cs
@@ -1,0 +1,73 @@
+using System.Buffers.Binary;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Exe.Signing;
+
+internal static class PeSignatureWriter
+{
+    private const ushort WinCertRevision2 = 0x0200;
+    private const ushort WinCertTypePkcsSignedData = 0x0002;
+
+    public static Result<byte[]> EmbedSignature(byte[] peData, byte[] pkcs7Signature)
+    {
+        return PeFile.Parse(peData).Map(pe => Embed(peData, pkcs7Signature, pe));
+    }
+
+    private static byte[] Embed(byte[] peData, byte[] pkcs7Signature, PeFile pe)
+    {
+        // WIN_CERTIFICATE: dwLength(4) + wRevision(2) + wCertificateType(2) + bCertificate(N)
+        int winCertHeaderSize = 8;
+        int winCertLength = winCertHeaderSize + pkcs7Signature.Length;
+        int paddedLength = AlignTo8(winCertLength);
+
+        // Place the certificate table at the end of the current file
+        int certTableOffset = peData.Length;
+        int totalSize = certTableOffset + paddedLength;
+
+        var result = new byte[totalSize];
+        Array.Copy(peData, result, peData.Length);
+
+        // Write WIN_CERTIFICATE structure
+        BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(certTableOffset), winCertLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(result.AsSpan(certTableOffset + 4), WinCertRevision2);
+        BinaryPrimitives.WriteUInt16LittleEndian(result.AsSpan(certTableOffset + 6), WinCertTypePkcsSignedData);
+        pkcs7Signature.CopyTo(result, certTableOffset + winCertHeaderSize);
+
+        // Update Certificate Table data directory entry
+        BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(pe.CertTableDirEntryOffset), certTableOffset);
+        BinaryPrimitives.WriteInt32LittleEndian(result.AsSpan(pe.CertTableDirEntryOffset + 4), paddedLength);
+
+        // Recalculate PE checksum
+        uint checksum = CalculatePeChecksum(result, pe.ChecksumOffset);
+        BinaryPrimitives.WriteUInt32LittleEndian(result.AsSpan(pe.ChecksumOffset), checksum);
+
+        return result;
+    }
+
+    private static int AlignTo8(int value) => (value + 7) & ~7;
+
+    internal static uint CalculatePeChecksum(byte[] data, int checksumOffset)
+    {
+        // Zero out the existing checksum field before computing
+        long checksum = 0;
+
+        for (int i = 0; i < data.Length; i += 2)
+        {
+            // Skip the 4-byte checksum field
+            if (i >= checksumOffset && i < checksumOffset + 4)
+                continue;
+
+            ushort word = (i + 1 < data.Length)
+                ? (ushort)(data[i] | (data[i + 1] << 8))
+                : data[i];
+
+            checksum += word;
+            checksum = (checksum & 0xFFFF) + (checksum >> 16);
+        }
+
+        checksum = (checksum & 0xFFFF) + (checksum >> 16);
+        checksum += data.Length;
+
+        return (uint)checksum;
+    }
+}

--- a/src/DotnetPackaging.Exe/Signing/PeSigner.cs
+++ b/src/DotnetPackaging.Exe/Signing/PeSigner.cs
@@ -1,0 +1,22 @@
+using System.Security.Cryptography.X509Certificates;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Exe.Signing;
+
+internal static class PeSigner
+{
+    public static Result<byte[]> Sign(byte[] peBytes, X509Certificate2 certificate)
+    {
+        return PeFile.Parse(peBytes)
+            .Map(pe => pe.ComputeAuthenticodeHash(peBytes))
+            .Bind(hash => AuthenticodeSigner.CreateSignature(hash, certificate))
+            .Bind(signature => PeSignatureWriter.EmbedSignature(peBytes, signature));
+    }
+
+    public static Result<byte[]> SignIfPe(byte[] data, X509Certificate2 certificate)
+    {
+        return PeFile.IsPeFile(data)
+            ? Sign(data, certificate)
+            : Result.Success(data);
+    }
+}

--- a/src/DotnetPackaging.Exe/SimpleExePacker.cs
+++ b/src/DotnetPackaging.Exe/SimpleExePacker.cs
@@ -5,11 +5,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.IO.Compression;
 
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Exe.Artifacts;
 using DotnetPackaging.Exe.Metadata;
+using DotnetPackaging.Exe.Signing;
 using Zafiro.DivineBytes;
 
 using System.Reactive.Linq;
@@ -24,33 +26,64 @@ internal static class SimpleExePacker
         IByteSource stub,
         IContainer publishDirectory,
         InstallerMetadata metadata,
-        Maybe<IByteSource> logoBytes)
+        Maybe<IByteSource> logoBytes,
+        Maybe<X509Certificate2> certificate = default)
     {
         return Result.Try(async () =>
         {
             var metadataSource = CreateMetadataSource(metadata);
 
             var uninstallerPayload = await CreateUninstallerPayload(metadataSource, stub);
-            var uninstaller = await AppendPayload(stub, uninstallerPayload);
+            var uninstallerRaw = await AppendPayload(stub, uninstallerPayload);
+            var uninstaller = await SignExeIfCertificate(uninstallerRaw, certificate);
 
-            var installerPayload = await CreateInstallerPayload(publishDirectory, metadataSource, uninstaller, logoBytes);
-            var installer = await AppendPayload(stub, installerPayload);
+            var installerPayload = await CreateInstallerPayload(publishDirectory, metadataSource, uninstaller, logoBytes, certificate);
+            var installerRaw = await AppendPayload(stub, installerPayload);
+            var installer = await SignExeIfCertificate(installerRaw, certificate);
 
             return new ExeBuildArtifacts(installer, uninstaller);
         }, ex => ex.Message);
+    }
+
+    private static async Task<IByteSource> SignExeIfCertificate(IByteSource source, Maybe<X509Certificate2> certificate)
+    {
+        if (certificate.HasNoValue)
+            return source;
+
+        var bytes = await ToBytes(source);
+        var result = PeSigner.SignIfPe(bytes, certificate.Value);
+        if (result.IsFailure)
+            throw new InvalidOperationException($"Failed to sign PE: {result.Error}");
+
+        return ByteSource.FromBytes(result.Value);
     }
 
     private static async Task<IByteSource> CreateInstallerPayload(
         IContainer publishDirectory,
         IByteSource metadata,
         IByteSource uninstaller,
-        Maybe<IByteSource> logoBytes)
+        Maybe<IByteSource> logoBytes,
+        Maybe<X509Certificate2> certificate)
     {
         var files = publishDirectory
             .ResourcesWithPathsRecursive()
             .ToDictionary(
                 file => $"Content/{file.FullPath().ToString().Replace('\\', '/')}",
                 file => (IByteSource)file);
+
+        // Sign all PE files in the publish directory before packaging
+        if (certificate.HasValue)
+        {
+            var signedFiles = new Dictionary<string, IByteSource>(files.Count, StringComparer.Ordinal);
+            foreach (var file in files)
+            {
+                var bytes = await ToBytes(file.Value);
+                var signed = PeSigner.SignIfPe(bytes, certificate.Value);
+                signedFiles[file.Key] = ByteSource.FromBytes(signed.IsSuccess ? signed.Value : bytes);
+            }
+
+            files = signedFiles;
+        }
 
         files["metadata.json"] = metadata;
         files["Support/Uninstaller.exe"] = uninstaller;

--- a/src/DotnetPackaging.Msix/Core/Signing/CertificateProvider.cs
+++ b/src/DotnetPackaging.Msix/Core/Signing/CertificateProvider.cs
@@ -1,44 +1,11 @@
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using CSharpFunctionalExtensions;
 
 namespace DotnetPackaging.Msix.Core.Signing;
 
+// Delegates to the shared implementation in DotnetPackaging.Signing
 internal static class CertificateProvider
 {
-    public static Result<X509Certificate2> Get(Maybe<string> pfxPath, Maybe<string> pfxPassword, string publisherCN)
-    {
-        return pfxPath.HasValue
-            ? LoadFromPfx(pfxPath.Value, pfxPassword.GetValueOrDefault(string.Empty))
-            : GenerateSelfSigned(publisherCN);
-    }
-
-    private static Result<X509Certificate2> LoadFromPfx(string path, string password)
-    {
-        return Result.Try(() => X509CertificateLoader.LoadPkcs12FromFile(path, password, X509KeyStorageFlags.Exportable));
-    }
-
-    private static Result<X509Certificate2> GenerateSelfSigned(string subjectName)
-    {
-        return Result.Try(() =>
-        {
-            using var rsa = RSA.Create(2048);
-            var request = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-
-            request.CertificateExtensions.Add(
-                new X509BasicConstraintsExtension(false, false, 0, false));
-            request.CertificateExtensions.Add(
-                new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, false));
-            request.CertificateExtensions.Add(
-                new X509EnhancedKeyUsageExtension(
-                    new OidCollection { new("1.3.6.1.5.5.7.3.3") }, // Code Signing
-                    false));
-
-            var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
-            var notAfter = DateTimeOffset.UtcNow.AddYears(1);
-            var cert = request.CreateSelfSigned(notBefore, notAfter);
-
-            return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
-        });
-    }
+    public static Result<System.Security.Cryptography.X509Certificates.X509Certificate2> Get(
+        Maybe<string> pfxPath, Maybe<string> pfxPassword, string publisherCN)
+        => DotnetPackaging.Signing.CertificateProvider.Get(pfxPath, pfxPassword, publisherCN);
 }

--- a/src/DotnetPackaging.Tool/Commands/ExeCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/ExeCommand.cs
@@ -46,6 +46,16 @@ public static class ExeCommand
             Required = false
         };
         exVendor.Aliases.Add("--company");
+        var pfxOption = new Option<FileInfo?>("--pfx")
+        {
+            Description = "Path to a PFX code signing certificate. All PE files and the final installer will be Authenticode-signed."
+        };
+        pfxOption.Recursive = true;
+        var pfxPasswordOption = new Option<string?>("--pfx-password")
+        {
+            Description = "Password for the PFX certificate file"
+        };
+        pfxPasswordOption.Recursive = true;
 
         var metadata = new MetadataOptionSet();
         var optionsBinder = metadata.CreateBinder();
@@ -64,6 +74,8 @@ public static class ExeCommand
         metadata.AddTo(exeCommand);
         exeCommand.Add(exVendor);
         exeCommand.Add(exArchTop);
+        exeCommand.Add(pfxOption);
+        exeCommand.Add(pfxPasswordOption);
 
         exeCommand.SetAction(async parseResult =>
         {
@@ -75,6 +87,8 @@ public static class ExeCommand
             var opt = optionsBinder.Bind(parseResult);
             var vendorOpt = parseResult.GetValue(exVendor);
             var archOpt = parseResult.GetValue(exArchTop);
+            var pfx = parseResult.GetValue(pfxOption);
+            var pfxPwd = parseResult.GetValue(pfxPasswordOption);
 
             await ExecutionWrapper.ExecuteWithLogging("exe", outFile.FullName, async logger =>
             {
@@ -104,7 +118,9 @@ public static class ExeCommand
                     RuntimeIdentifier = Maybe.From(ridResult.Value),
                     Stub = stubBytes == null ? Maybe<IByteSource>.None : Maybe.From(stubBytes),
                     SetupLogo = logoBytes == null ? Maybe<IByteSource>.None : Maybe.From(logoBytes),
-                    OutputName = Maybe.From(outFile.Name)
+                    OutputName = Maybe.From(outFile.Name),
+                    PfxPath = pfx != null ? Maybe.From(pfx.FullName) : Maybe<string>.None,
+                    PfxPassword = pfxPwd != null ? Maybe.From(pfxPwd) : Maybe<string>.None
                 };
 
                 var result = await packager.Pack(containerResult, exeMetadata);
@@ -159,6 +175,8 @@ public static class ExeCommand
         fromDirectory.Add(fdSetupLogo);
         fromDirectory.Add(exVendor);
         fromDirectory.Add(fdArch);
+        fromDirectory.Add(pfxOption);
+        fromDirectory.Add(pfxPasswordOption);
         fdMetadata.AddTo(fromDirectory);
 
         fromDirectory.SetAction(async parseResult =>
@@ -170,6 +188,8 @@ public static class ExeCommand
             var opt = fdBinder.Bind(parseResult);
             var vendorOpt = parseResult.GetValue(exVendor);
             var archOpt = parseResult.GetValue(fdArch);
+            var pfx = parseResult.GetValue(pfxOption);
+            var pfxPwd = parseResult.GetValue(pfxPasswordOption);
 
             await ExecutionWrapper.ExecuteWithLogging("exe", outFile.FullName, async logger =>
             {
@@ -199,7 +219,9 @@ public static class ExeCommand
                     RuntimeIdentifier = Maybe.From(ridResult.Value),
                     Stub = stubBytes == null ? Maybe<IByteSource>.None : Maybe.From(stubBytes),
                     SetupLogo = logoBytes == null ? Maybe<IByteSource>.None : Maybe.From(logoBytes),
-                    OutputName = Maybe.From(outFile.Name)
+                    OutputName = Maybe.From(outFile.Name),
+                    PfxPath = pfx != null ? Maybe.From(pfx.FullName) : Maybe<string>.None,
+                    PfxPassword = pfxPwd != null ? Maybe.From(pfxPwd) : Maybe<string>.None
                 };
 
                 var result = await packager.Pack(containerResult, exeMetadata);
@@ -238,6 +260,8 @@ public static class ExeCommand
         project.AddTo(exFromProject);
         exFromProject.Add(exStub);
         exFromProject.Add(exSetupLogo);
+        exFromProject.Add(pfxOption);
+        exFromProject.Add(pfxPasswordOption);
 
         exFromProject.SetAction(async parseResult =>
         {
@@ -250,6 +274,8 @@ public static class ExeCommand
             var extrasStub = parseResult.GetValue(exStub);
             var extrasLogo = parseResult.GetValue(exSetupLogo);
             var vendorOpt = parseResult.GetValue(exVendor);
+            var pfx = parseResult.GetValue(pfxOption);
+            var pfxPwd = parseResult.GetValue(pfxPasswordOption);
             var opt = optionsBinder.Bind(parseResult);
             var logger = Log.ForContext("command", "exe-from-project");
 
@@ -282,6 +308,8 @@ public static class ExeCommand
                     exeMetadata.SetupLogo = logoBytes == null ? Maybe<IByteSource>.None : Maybe.From(logoBytes);
                     exeMetadata.RuntimeIdentifier = ridHint;
                     exeMetadata.OutputName = Maybe.From(extrasOutput.Name);
+                    exeMetadata.PfxPath = pfx != null ? Maybe.From(pfx.FullName) : Maybe<string>.None;
+                    exeMetadata.PfxPassword = pfxPwd != null ? Maybe.From(pfxPwd) : Maybe<string>.None;
                 },
                 pub =>
                 {

--- a/src/DotnetPackaging/Signing/CertificateProvider.cs
+++ b/src/DotnetPackaging/Signing/CertificateProvider.cs
@@ -1,0 +1,44 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Signing;
+
+public static class CertificateProvider
+{
+    public static Result<X509Certificate2> Get(Maybe<string> pfxPath, Maybe<string> pfxPassword, string publisherCN)
+    {
+        return pfxPath.HasValue
+            ? LoadFromPfx(pfxPath.Value, pfxPassword.GetValueOrDefault(string.Empty))
+            : GenerateSelfSigned(publisherCN);
+    }
+
+    public static Result<X509Certificate2> LoadFromPfx(string path, string password)
+    {
+        return Result.Try(() => X509CertificateLoader.LoadPkcs12FromFile(path, password, X509KeyStorageFlags.Exportable));
+    }
+
+    private static Result<X509Certificate2> GenerateSelfSigned(string subjectName)
+    {
+        return Result.Try(() =>
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+            request.CertificateExtensions.Add(
+                new X509BasicConstraintsExtension(false, false, 0, false));
+            request.CertificateExtensions.Add(
+                new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, false));
+            request.CertificateExtensions.Add(
+                new X509EnhancedKeyUsageExtension(
+                    new OidCollection { new("1.3.6.1.5.5.7.3.3") }, // Code Signing
+                    false));
+
+            var notBefore = DateTimeOffset.UtcNow.AddMinutes(-5);
+            var notAfter = DateTimeOffset.UtcNow.AddYears(1);
+            var cert = request.CreateSelfSigned(notBefore, notAfter);
+
+            return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
+        });
+    }
+}

--- a/test/DotnetPackaging.Exe.Tests/AuthenticodeSigningTests.cs
+++ b/test/DotnetPackaging.Exe.Tests/AuthenticodeSigningTests.cs
@@ -1,0 +1,190 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using DotnetPackaging.Exe.Signing;
+using FluentAssertions;
+
+namespace DotnetPackaging.Exe.Tests;
+
+public class AuthenticodeSigningTests
+{
+    private static byte[] CreateMinimalPe()
+    {
+        // Build a minimal PE32+ (x64) that is valid enough for our parser and signer.
+        // DOS header (64 bytes) + PE signature (4) + COFF header (20) + Optional header (240) = 328 bytes
+        var pe = new byte[512];
+
+        // DOS header
+        pe[0] = 0x4D; pe[1] = 0x5A; // MZ
+        BinaryPrimitives.WriteInt32LittleEndian(pe.AsSpan(0x3C), 64); // e_lfanew → PE starts at 64
+
+        // PE signature
+        pe[64] = 0x50; pe[65] = 0x45; pe[66] = 0x00; pe[67] = 0x00;
+
+        // COFF header (20 bytes at offset 68)
+        BinaryPrimitives.WriteUInt16LittleEndian(pe.AsSpan(68), 0x8664); // Machine: AMD64
+        BinaryPrimitives.WriteUInt16LittleEndian(pe.AsSpan(70), 1);      // NumberOfSections: 1
+        BinaryPrimitives.WriteUInt16LittleEndian(pe.AsSpan(84), 240);    // SizeOfOptionalHeader
+
+        // Optional header (starts at offset 88)
+        BinaryPrimitives.WriteUInt16LittleEndian(pe.AsSpan(88), 0x20B); // Magic: PE32+
+        // Checksum is at optional header offset 64 → absolute 88+64 = 152
+        // Cert table is at data dir offset 112 + 4*8 = 144 → absolute 88+144 = 232
+        // NumberOfRvaAndSizes at offset 108 → absolute 88+108 = 196
+        BinaryPrimitives.WriteInt32LittleEndian(pe.AsSpan(196), 16); // NumberOfRvaAndSizes
+
+        // Section header (at offset 88+240 = 328, 40 bytes)
+        // .text section
+        pe[328] = (byte)'.'; pe[329] = (byte)'t'; pe[330] = (byte)'e'; pe[331] = (byte)'x'; pe[332] = (byte)'t';
+        BinaryPrimitives.WriteInt32LittleEndian(pe.AsSpan(328 + 8), 128);  // VirtualSize
+        BinaryPrimitives.WriteInt32LittleEndian(pe.AsSpan(328 + 12), 0x1000); // VirtualAddress
+        BinaryPrimitives.WriteInt32LittleEndian(pe.AsSpan(328 + 16), 128); // SizeOfRawData
+        BinaryPrimitives.WriteInt32LittleEndian(pe.AsSpan(328 + 20), 368); // PointerToRawData
+
+        // Fill section data with some bytes
+        for (int i = 368; i < 496; i++) pe[i] = (byte)(i & 0xFF);
+
+        return pe;
+    }
+
+    private static X509Certificate2 CreateTestCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Test Code Signing", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, false));
+        request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+            new OidCollection { new("1.3.6.1.5.5.7.3.3") }, false));
+        var cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow.AddHours(1));
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
+    }
+
+    [Fact]
+    public void PeFile_should_detect_valid_pe()
+    {
+        var pe = CreateMinimalPe();
+        PeFile.IsPeFile(pe).Should().BeTrue();
+    }
+
+    [Fact]
+    public void PeFile_should_reject_non_pe()
+    {
+        PeFile.IsPeFile(new byte[] { 0x00, 0x01, 0x02, 0x03 }).Should().BeFalse();
+        PeFile.IsPeFile(Array.Empty<byte>()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void PeFile_should_parse_minimal_pe()
+    {
+        var pe = CreateMinimalPe();
+        var result = PeFile.Parse(pe);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.IsPe32Plus.Should().BeTrue();
+        result.Value.ChecksumOffset.Should().Be(88 + 64); // optional header + 64
+        result.Value.CertTableDirEntryOffset.Should().Be(88 + 112 + 4 * 8); // optional header + 112 + 32
+    }
+
+    [Fact]
+    public void PeFile_should_compute_authenticode_hash()
+    {
+        var pe = CreateMinimalPe();
+        var parsed = PeFile.Parse(pe);
+        parsed.IsSuccess.Should().BeTrue();
+
+        var hash = parsed.Value.ComputeAuthenticodeHash(pe);
+        hash.Should().HaveCount(32); // SHA-256
+        hash.Should().NotBeEquivalentTo(new byte[32]); // not all zeros
+    }
+
+    [Fact]
+    public void AuthenticodeSigner_should_create_pkcs7_signature()
+    {
+        var hash = SHA256.HashData(new byte[] { 1, 2, 3, 4 });
+        using var cert = CreateTestCertificate();
+
+        var result = AuthenticodeSigner.CreateSignature(hash, cert);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeEmpty();
+        // PKCS#7 signatures start with SEQUENCE tag (0x30)
+        result.Value[0].Should().Be(0x30);
+    }
+
+    [Fact]
+    public void PeSignatureWriter_should_embed_signature_in_pe()
+    {
+        var pe = CreateMinimalPe();
+        var fakeSignature = new byte[256];
+        Random.Shared.NextBytes(fakeSignature);
+
+        var result = PeSignatureWriter.EmbedSignature(pe, fakeSignature);
+        result.IsSuccess.Should().BeTrue();
+
+        var signed = result.Value;
+        signed.Length.Should().BeGreaterThan(pe.Length);
+
+        // Certificate table directory entry should be updated
+        var parsed = PeFile.Parse(signed);
+        parsed.IsSuccess.Should().BeTrue();
+        parsed.Value.CertTableDataOffset.Should().Be(pe.Length); // cert appended at end
+        parsed.Value.CertTableDataSize.Should().BeGreaterThan(0);
+
+        // WIN_CERTIFICATE header: dwLength (4) + wRevision (2) + wCertificateType (2)
+        int certOffset = pe.Length;
+        var winCertLength = BinaryPrimitives.ReadInt32LittleEndian(signed.AsSpan(certOffset));
+        winCertLength.Should().Be(8 + fakeSignature.Length);
+        var revision = BinaryPrimitives.ReadUInt16LittleEndian(signed.AsSpan(certOffset + 4));
+        revision.Should().Be(0x0200);
+        var certType = BinaryPrimitives.ReadUInt16LittleEndian(signed.AsSpan(certOffset + 6));
+        certType.Should().Be(0x0002);
+
+        // PE checksum should be non-zero
+        var checksum = BinaryPrimitives.ReadUInt32LittleEndian(signed.AsSpan(parsed.Value.ChecksumOffset));
+        checksum.Should().NotBe(0);
+    }
+
+    [Fact]
+    public void PeSigner_should_sign_pe_end_to_end()
+    {
+        var pe = CreateMinimalPe();
+        using var cert = CreateTestCertificate();
+
+        var result = PeSigner.Sign(pe, cert);
+        result.IsSuccess.Should().BeTrue();
+
+        var signed = result.Value;
+        signed.Length.Should().BeGreaterThan(pe.Length);
+
+        // Should still be a valid PE
+        PeFile.IsPeFile(signed).Should().BeTrue();
+
+        // Certificate table should be populated
+        var parsed = PeFile.Parse(signed);
+        parsed.IsSuccess.Should().BeTrue();
+        parsed.Value.CertTableDataOffset.Should().BeGreaterThan(0);
+        parsed.Value.CertTableDataSize.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void PeSigner_SignIfPe_should_pass_through_non_pe_data()
+    {
+        using var cert = CreateTestCertificate();
+        var notPe = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+        var result = PeSigner.SignIfPe(notPe, cert);
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(notPe);
+    }
+
+    [Fact]
+    public void PeChecksum_should_be_deterministic()
+    {
+        var pe = CreateMinimalPe();
+        int checksumOffset = 88 + 64; // known from our minimal PE
+
+        var checksum1 = PeSignatureWriter.CalculatePeChecksum(pe, checksumOffset);
+        var checksum2 = PeSignatureWriter.CalculatePeChecksum(pe, checksumOffset);
+
+        checksum1.Should().Be(checksum2);
+        checksum1.Should().NotBe(0);
+    }
+}


### PR DESCRIPTION
## Summary

Managed Authenticode code signing for the Windows EXE installer — zero external tools required.

When the user provides a PFX certificate (`--pfx` / `--pfx-password`), all PE files in the payload, the uninstaller, and the final Setup.exe are signed automatically. If no certificate is provided, a warning about SmartScreen consequences is emitted.

## What's included

| Component | Description |
|---|---|
| `PeFile` | PE header parser + Authenticode SHA-256 hash computation |
| `AuthenticodeSigner` | PKCS#7 signature with `SPC_INDIRECT_DATA_CONTENT` |
| `PeSignatureWriter` | Embeds `WIN_CERTIFICATE`, updates cert table and checksum |
| `PeSigner` | High-level orchestrator |
| Pipeline wiring | Signs content PEs before zip, then uninstaller, then installer |
| CLI options | `--pfx` and `--pfx-password` on all three exe subcommands |
| SmartScreen warning | Emitted when no certificate is provided |
| Shared `CertificateProvider` | Moved to base lib; MSIX delegates to it |
| Tests | 9 new unit tests (PE parsing, hash, PKCS#7, embedding, E2E, passthrough, checksum) |

## Signing order

1. Sign all `.exe`/`.dll` files in the publish directory
2. Build uninstaller payload, append to stub, sign uninstaller EXE
3. Build installer payload (with signed content + signed uninstaller), append to stub, sign installer EXE

## CLI usage

```
dotnetpackaging exe --directory ./publish --output Setup.exe --pfx cert.pfx --pfx-password secret
dotnetpackaging exe from-project --project MyApp.csproj --output Setup.exe --pfx cert.pfx
```

## Test results

- 18 passed, 5 skipped (pre-existing), 0 failures
- 9 new Authenticode signing tests all green