### PR TITLE
[codex] Make DMG validation tests hermetic

### DIFF
--- a/src/DotnetPackaging.Dmg/Verification/DmgVerifier.cs
+++ b/src/DotnetPackaging.Dmg/Verification/DmgVerifier.cs
@@ -20,7 +20,7 @@ public static class DmgVerifier
             using var fs = File.OpenRead(dmgPath);
             if (IsIso9660(fs))
             {
-                return Result.Success("ISO/UDTO DMG detected (content not enumerated)");
+                return Result.Success("ISO/UDTO DMG structural-only validation OK (content not enumerated)");
             }
         }
         catch (Exception ex)
@@ -43,7 +43,7 @@ public static class DmgVerifier
                 return Result.Failure<string>("UDIF detected but HFS+ signature not found");
             }
 
-            return Result.Success($"UDIF DMG OK (runs={udif.Runs.Count}, sectors={udif.Trailer.SectorCount})");
+            return Result.Success($"UDIF DMG structural-only validation OK (runs={udif.Runs.Count}, sectors={udif.Trailer.SectorCount})");
         }
         catch (Exception ex) when (ex is InvalidDataException || ex is IOException)
         {

--- a/test/DotnetPackaging.Dmg.Tests/BTreeTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/BTreeTests.cs
@@ -79,21 +79,21 @@ public class BTreeTests
 
         // Assert
         // Node Descriptor = 14 bytes.
-        // Record 0 starts at 14. Len 3. Ends at 17.
-        // Record 1 starts at 17. Len 2. Ends at 19.
-        // Free space starts at 19.
+        // Record 0 starts at 14. Len 3 plus 1 byte of HFS+ even-byte alignment. Ends at 18.
+        // Record 1 starts at 18. Len 2. Ends at 20.
+        // Free space starts at 20.
         
         // Offsets at end of node:
         // 510-511: Offset 0 (14)
-        // 508-509: Offset 1 (17)
-        // 506-507: Offset 2 (19) - Start of free space
+        // 508-509: Offset 1 (18)
+        // 506-507: Offset 2 (20) - Start of free space
         
         BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(510, 2)).Should().Be(14);
-        BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(508, 2)).Should().Be(17);
-        BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(506, 2)).Should().Be(19);
+        BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(508, 2)).Should().Be(18);
+        BinaryPrimitives.ReadUInt16BigEndian(bytes.AsSpan(506, 2)).Should().Be(20);
 
         // Verify content
         bytes[14].Should().Be(0xAA);
-        bytes[17].Should().Be(0x11);
+        bytes[18].Should().Be(0x11);
     }
 }

--- a/test/DotnetPackaging.Dmg.Tests/DmgExternalValidationTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgExternalValidationTests.cs
@@ -144,7 +144,14 @@ public class DmgExternalValidationTests
         var device = devices.FirstOrDefault()?.Device;
         if (!string.IsNullOrWhiteSpace(device))
         {
-            await ExternalDmgValidationTools.Run(hdiutil, "detach", device, "-force");
+            var detach = await ExternalDmgValidationTools.Run(hdiutil, "detach", device, "-force");
+            detach.ExitCode.Should().Be(
+                0,
+                "hdiutil detach failed for {0}.{1}stdout:{1}{2}{1}stderr:{1}{3}",
+                device,
+                Environment.NewLine,
+                detach.StdOut,
+                detach.StdErr);
         }
     }
 }

--- a/test/DotnetPackaging.Dmg.Tests/DmgExternalValidationTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgExternalValidationTests.cs
@@ -8,6 +8,34 @@ namespace DotnetPackaging.Dmg.Tests;
 
 public class DmgExternalValidationTests
 {
+    [Fact]
+    public void Hdiutil_plist_parser_reads_attached_hfs_devices()
+    {
+        const string plist = """
+                             <?xml version="1.0" encoding="UTF-8"?>
+                             <plist version="1.0">
+                             <dict>
+                                 <key>system-entities</key>
+                                 <array>
+                                     <dict>
+                                         <key>dev-entry</key>
+                                         <string>/dev/disk5</string>
+                                         <key>mount-point</key>
+                                         <string>/Volumes/Test App</string>
+                                         <key>content-hint</key>
+                                         <string>Apple_HFS</string>
+                                     </dict>
+                                 </array>
+                             </dict>
+                             </plist>
+                             """;
+
+        var devices = ExternalDmgValidationTools.ParseHdiutilDevices(plist);
+
+        devices.Should().ContainSingle().Which.Should().Be(
+            new HdiutilDevice("/dev/disk5", "/Volumes/Test App", "Apple_HFS"));
+    }
+
     [SkippableFact]
     public async Task Default_packager_dmg_validates_with_external_hfs_tool_when_available()
     {
@@ -31,8 +59,7 @@ public class DmgExternalValidationTests
         var hdiutil = ExternalDmgValidationTools.FindHdiutil();
         if (hdiutil != null)
         {
-            var verify = await ExternalDmgValidationTools.Run(hdiutil, "verify", outDmg);
-            verify.ExitCode.Should().Be(0, verify.StdOut + verify.StdErr);
+            await ValidateWithHdiutil(hdiutil, outDmg, tempRoot.Path);
             return;
         }
 
@@ -46,5 +73,78 @@ public class DmgExternalValidationTests
 
         var check = await ExternalDmgValidationTools.Run(fsck, "-n", outImg);
         check.ExitCode.Should().Be(0, check.StdOut + check.StdErr);
+    }
+
+    private static async Task ValidateWithHdiutil(string hdiutil, string dmgPath, string tempRoot)
+    {
+        var verify = await ExternalDmgValidationTools.Run(hdiutil, "verify", dmgPath);
+        verify.ExitCode.Should().Be(0, verify.StdOut + verify.StdErr);
+
+        await ValidateMountability(hdiutil, dmgPath, tempRoot);
+        await ValidateHfsVolume(hdiutil, dmgPath);
+    }
+
+    private static async Task ValidateMountability(string hdiutil, string dmgPath, string tempRoot)
+    {
+        var mountPath = Path.Combine(tempRoot, "mount");
+        Directory.CreateDirectory(mountPath);
+
+        IReadOnlyList<HdiutilDevice> devices = [];
+        try
+        {
+            var attach = await ExternalDmgValidationTools.Run(
+                hdiutil,
+                "attach",
+                "-readonly",
+                "-nobrowse",
+                "-plist",
+                "-mountpoint",
+                mountPath,
+                dmgPath);
+            attach.ExitCode.Should().Be(0, attach.StdOut + attach.StdErr);
+
+            devices = ExternalDmgValidationTools.ParseHdiutilDevices(attach.StdOut);
+            var mountedDevice = devices.FirstOrDefault(device => !string.IsNullOrWhiteSpace(device.MountPoint));
+            mountedDevice.Should().NotBeNull(attach.StdOut + attach.StdErr);
+            Directory.Exists(mountedDevice!.MountPoint).Should().BeTrue(attach.StdOut + attach.StdErr);
+        }
+        finally
+        {
+            await DetachDevices(hdiutil, devices);
+        }
+    }
+
+    private static async Task ValidateHfsVolume(string hdiutil, string dmgPath)
+    {
+        var fsck = ExternalDmgValidationTools.FindHfsFsck();
+        Skip.If(fsck == null, "Requires fsck_hfs for mounted DMG HFS+ validation.");
+
+        IReadOnlyList<HdiutilDevice> devices = [];
+        try
+        {
+            var attach = await ExternalDmgValidationTools.Run(hdiutil, "attach", "-readonly", "-nomount", "-plist", dmgPath);
+            attach.ExitCode.Should().Be(0, attach.StdOut + attach.StdErr);
+
+            devices = ExternalDmgValidationTools.ParseHdiutilDevices(attach.StdOut);
+            var hfsDevice = devices.FirstOrDefault(device =>
+                device.ContentHint?.Contains("HFS", StringComparison.OrdinalIgnoreCase) == true);
+
+            hfsDevice.Should().NotBeNull(attach.StdOut + attach.StdErr);
+            var check = await ExternalDmgValidationTools.Run(fsck, "-n", hfsDevice!.Device!);
+            check.ExitCode.Should().Be(0, check.StdOut + check.StdErr);
+        }
+        finally
+        {
+            await DetachDevices(hdiutil, devices);
+        }
+    }
+
+    private static async Task DetachDevices(string hdiutil, IReadOnlyList<HdiutilDevice> devices)
+    {
+        var device = devices.FirstOrDefault()?.Device;
+        if (!string.IsNullOrWhiteSpace(device))
+        {
+            await ExternalDmgValidationTools.Run(hdiutil, "detach", device, "-force");
+        }
     }
 }

--- a/test/DotnetPackaging.Dmg.Tests/DmgExternalValidationTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgExternalValidationTests.cs
@@ -1,0 +1,50 @@
+using CSharpFunctionalExtensions;
+using FluentAssertions;
+using Zafiro.DivineBytes;
+using Zafiro.DivineBytes.System.IO;
+using Path = System.IO.Path;
+
+namespace DotnetPackaging.Dmg.Tests;
+
+public class DmgExternalValidationTests
+{
+    [SkippableFact]
+    public async Task Default_packager_dmg_validates_with_external_hfs_tool_when_available()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+
+        var outDmg = Path.Combine(tempRoot.Path, "TestApp.dmg");
+        var container = new DirectoryContainer(new System.IO.Abstractions.FileSystem().DirectoryInfo.New(publish)).AsRoot();
+        var metadata = new DmgPackagerMetadata
+        {
+            VolumeName = Maybe.From("Test App"),
+            ExecutableName = Maybe.From("TestApp")
+        };
+
+        var result = await new DmgPackager().Pack(container, metadata);
+        result.IsSuccess.Should().BeTrue();
+        await result.Value.WriteTo(outDmg);
+
+        var hdiutil = ExternalDmgValidationTools.FindHdiutil();
+        if (hdiutil != null)
+        {
+            var verify = await ExternalDmgValidationTools.Run(hdiutil, "verify", outDmg);
+            verify.ExitCode.Should().Be(0, verify.StdOut + verify.StdErr);
+            return;
+        }
+
+        var dmg2img = ExternalDmgValidationTools.FindDmg2Img();
+        var fsck = ExternalDmgValidationTools.FindHfsFsck();
+        Skip.If(dmg2img == null || fsck == null, "Requires hdiutil, or both dmg2img and fsck.hfsplus/fsck_hfs.");
+
+        var outImg = Path.Combine(tempRoot.Path, "TestApp.img");
+        var convert = await ExternalDmgValidationTools.Run(dmg2img, outDmg, outImg);
+        convert.ExitCode.Should().Be(0, convert.StdOut + convert.StdErr);
+
+        var check = await ExternalDmgValidationTools.Run(fsck, "-n", outImg);
+        check.ExitCode.Should().Be(0, check.StdOut + check.StdErr);
+    }
+}

--- a/test/DotnetPackaging.Dmg.Tests/DmgVerifierTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgVerifierTests.cs
@@ -1,0 +1,25 @@
+using DotnetPackaging.Dmg.Verification;
+using FluentAssertions;
+using Path = System.IO.Path;
+
+namespace DotnetPackaging.Dmg.Tests;
+
+public class DmgVerifierTests
+{
+    [Fact]
+    public async Task Verify_udif_dmg_reports_structural_only_validation()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+
+        var outDmg = Path.Combine(tempRoot.Path, "Test.dmg");
+        await DmgHfsBuilder.Create(publish, outDmg, "Test App");
+
+        var result = await DmgVerifier.Verify(outDmg);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Contain("structural-only");
+    }
+}

--- a/test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj
+++ b/test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/DotnetPackaging.Dmg.Tests/ExternalDmgValidationTools.cs
+++ b/test/DotnetPackaging.Dmg.Tests/ExternalDmgValidationTools.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Xml.Linq;
 
 namespace DotnetPackaging.Dmg.Tests;
 
@@ -45,6 +46,50 @@ internal static class ExternalDmgValidationTools
         return new ProcessResult(process.ExitCode, await stdout, await stderr);
     }
 
+    public static IReadOnlyList<HdiutilDevice> ParseHdiutilDevices(string plist)
+    {
+        var document = XDocument.Parse(plist);
+        var rootDictionary = document.Root?.Element("dict");
+        var entities = FindValue(rootDictionary, "system-entities");
+        if (entities?.Name != "array")
+        {
+            return [];
+        }
+
+        return entities.Elements("dict")
+            .Select(device => new HdiutilDevice(
+                ReadString(device, "dev-entry"),
+                ReadString(device, "mount-point"),
+                ReadString(device, "content-hint")))
+            .Where(device => !string.IsNullOrWhiteSpace(device.Device))
+            .ToArray();
+    }
+
+    private static XElement? FindValue(XElement? dictionary, string key)
+    {
+        if (dictionary == null)
+        {
+            return null;
+        }
+
+        var elements = dictionary.Elements().ToArray();
+        for (var i = 0; i < elements.Length - 1; i++)
+        {
+            if (elements[i].Name == "key" && elements[i].Value == key)
+            {
+                return elements[i + 1];
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ReadString(XElement dictionary, string key)
+    {
+        var value = FindValue(dictionary, key);
+        return value?.Name == "string" ? value.Value : null;
+    }
+
     private static string? FindExecutable(string name)
     {
         var path = Environment.GetEnvironmentVariable("PATH");
@@ -53,7 +98,12 @@ internal static class ExternalDmgValidationTools
             return null;
         }
 
-        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        var directories = path
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Concat(["/sbin", "/usr/sbin", "/bin", "/usr/bin"])
+            .Distinct();
+
+        foreach (var directory in directories)
         {
             var candidate = Path.Combine(directory, name);
             if (File.Exists(candidate))
@@ -67,3 +117,5 @@ internal static class ExternalDmgValidationTools
 }
 
 internal sealed record ProcessResult(int ExitCode, string StdOut, string StdErr);
+
+internal sealed record HdiutilDevice(string? Device, string? MountPoint, string? ContentHint);

--- a/test/DotnetPackaging.Dmg.Tests/ExternalDmgValidationTools.cs
+++ b/test/DotnetPackaging.Dmg.Tests/ExternalDmgValidationTools.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+
+namespace DotnetPackaging.Dmg.Tests;
+
+internal static class ExternalDmgValidationTools
+{
+    public static string? FindHdiutil()
+    {
+        return FindExecutable("hdiutil");
+    }
+
+    public static string? FindDmg2Img()
+    {
+        return FindExecutable("dmg2img");
+    }
+
+    public static string? FindHfsFsck()
+    {
+        return OperatingSystem.IsMacOS()
+            ? FindExecutable("fsck_hfs") ?? FindExecutable("fsck.hfsplus")
+            : FindExecutable("fsck.hfsplus") ?? FindExecutable("fsck_hfs");
+    }
+
+    public static async Task<ProcessResult> Run(string fileName, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Unable to start '{fileName}'.");
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return new ProcessResult(process.ExitCode, await stdout, await stderr);
+    }
+
+    private static string? FindExecutable(string name)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var candidate = Path.Combine(directory, name);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+}
+
+internal sealed record ProcessResult(int ExitCode, string StdOut, string StdErr);

--- a/test/DotnetPackaging.Dmg.Tests/HfsCorruptionTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/HfsCorruptionTests.cs
@@ -8,16 +8,19 @@ namespace DotnetPackaging.Dmg.Tests;
 
 public class HfsCorruptionTests
 {
-    private readonly ITestOutputHelper _output;
+    private readonly ITestOutputHelper output;
 
     public HfsCorruptionTests(ITestOutputHelper output)
     {
-        _output = output;
+        this.output = output;
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task ShouldCreateValidHfsVolume()
     {
+        var fsck = ExternalDmgValidationTools.FindHfsFsck();
+        Skip.If(fsck == null, "Requires fsck_hfs on macOS or fsck.hfsplus on Linux.");
+
         // Assemble
         var builder = HfsVolumeBuilder.Create("TestHFS")
             .WithBlockSize(4096);
@@ -50,17 +53,17 @@ public class HfsCorruptionTests
         try
         {
             await File.WriteAllBytesAsync(imgPath, bytes);
-            _output.WriteLine($"Generated HFS+ image at: {imgPath}");
+            output.WriteLine($"Generated HFS+ image at: {imgPath}");
 
             // Verify
-            var (exitCode, stdout, stderr) = await RunFsck(imgPath);
+            var (exitCode, stdout, stderr) = await RunFsck(fsck, imgPath);
             
-            _output.WriteLine("fsck_hfs output:");
-            _output.WriteLine(stdout);
+            output.WriteLine("HFS+ fsck output:");
+            output.WriteLine(stdout);
             if (!string.IsNullOrEmpty(stderr))
             {
-                _output.WriteLine("fsck_hfs errors:");
-                _output.WriteLine(stderr);
+                output.WriteLine("HFS+ fsck errors:");
+                output.WriteLine(stderr);
             }
 
             // Assert
@@ -75,17 +78,18 @@ public class HfsCorruptionTests
         }
     }
 
-    private async Task<(int ExitCode, string StdOut, string StdErr)> RunFsck(string imagePath)
+    private static async Task<(int ExitCode, string StdOut, string StdErr)> RunFsck(string fsck, string imagePath)
     {
         var startInfo = new ProcessStartInfo
         {
-            FileName = "fsck_hfs",
-            Arguments = $"-n \"{imagePath}\"",
+            FileName = fsck,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true
         };
+        startInfo.ArgumentList.Add("-n");
+        startInfo.ArgumentList.Add(imagePath);
 
         using var process = new Process { StartInfo = startInfo };
         process.Start();

--- a/test/DotnetPackaging.Dmg.Tests/InspectDmgTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/InspectDmgTests.cs
@@ -8,38 +8,29 @@ namespace DotnetPackaging.Dmg.Tests;
 
 public class InspectDmgTests
 {
-    private readonly ITestOutputHelper _output;
-    private readonly StringBuilder _sb = new();
+    private const string InspectPathVariable = "DOTNETPACKAGING_DMG_INSPECT_PATH";
+    private readonly ITestOutputHelper output;
+    private readonly StringBuilder logBuffer = new();
 
     public InspectDmgTests(ITestOutputHelper output)
     {
-        _output = output;
+        this.output = output;
     }
     
     private void Log(string msg)
     {
-        _output.WriteLine(msg);
-        _sb.AppendLine(msg);
+        output.WriteLine(msg);
+        logBuffer.AppendLine(msg);
     }
 
-    [Fact]
+    [SkippableFact]
     public void InspectCatalogRootNode()
     {
-        // Must convert first!
-        // var dmgPath = "/Users/jmn/RiderProjects/DotnetPackaging/Output_raw.dmg.cdr";
-        // Assuming user runs hdiutil convert manually or we use Output.dmg if we fix the reader.
-        // For now, let's keep it pointing to cdr but note it might be stale unless we reconvert.
-        var dmgPath = "/Users/jmn/RiderProjects/DotnetPackaging/Output_raw.dmg.cdr";
-        if (!File.Exists(dmgPath))
-        {
-            Log("Output.dmg not found.");
-            Assert.Fail($"Output.dmg not found at {dmgPath}"); 
-            return;
-        }
+        var dmgPath = Environment.GetEnvironmentVariable(InspectPathVariable);
+        Skip.If(string.IsNullOrWhiteSpace(dmgPath), $"Set {InspectPathVariable} to inspect a local raw HFS image.");
+        Skip.IfNot(File.Exists(dmgPath), $"Inspection file not found at {dmgPath}.");
 
-        using var stream = File.OpenRead(dmgPath);
-        var buffer = new byte[stream.Length];
-        stream.Read(buffer);
+        var buffer = File.ReadAllBytes(dmgPath);
 
         // Debug: Print first 16 bytes and VH start
         var head = BitConverter.ToString(buffer.AsSpan(0, 16).ToArray());
@@ -198,6 +189,6 @@ public class InspectDmgTests
             }
         }
         
-        File.WriteAllText("debug_tree.txt", _sb.ToString());
+        File.WriteAllText("debug_tree.txt", logBuffer.ToString());
     }
 }


### PR DESCRIPTION
## Summary
- make DMG validation tests hermetic by skipping manual/local-tool checks when inputs are unavailable
- add optional external HFS validation for default packager output when hdiutil or dmg2img/fsck is installed
- make dmg verify report structural-only validation scope

## Validation
- dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj
- dotnet build DotnetPackaging.sln

Closes #176