### PR TITLE
[codex] Clean up temporary DMG image files

### DIFF
--- a/src/DotnetPackaging.Dmg/DmgPackager.cs
+++ b/src/DotnetPackaging.Dmg/DmgPackager.cs
@@ -24,19 +24,21 @@ public sealed class DmgPackager
             throw new ArgumentNullException(nameof(metadata));
         }
 
-        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString("N"));
-        var dmgPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dp-dmg-{System.Guid.NewGuid():N}.dmg");
+        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dmgPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dp-dmg-{Guid.NewGuid():N}.dmg");
         try
         {
             var writeResult = await container.WriteTo(tempDir);
             if (writeResult.IsFailure)
             {
+                TryDeleteFile(dmgPath);
                 return Result.Failure<IByteSource>(writeResult.Error);
             }
 
             var volumeName = metadata.VolumeName
                 .Or(metadata.ExecutableName)
                 .GetValueOrDefault("Application");
+            var executableName = metadata.ExecutableName.HasValue ? metadata.ExecutableName.Value : null;
 
             await DmgHfsBuilder.Create(
                 tempDir,
@@ -46,16 +48,35 @@ public sealed class DmgPackager
                 metadata.AddApplicationsSymlink.GetValueOrDefault(true),
                 metadata.IncludeDefaultLayout.GetValueOrDefault(true),
                 metadata.Icon,
-                metadata.ExecutableName.GetValueOrDefault(null));
+                executableName);
 
-            return Result.Success<IByteSource>(FileByteSource.OpenRead(dmgPath));
+            return Result.Success<IByteSource>(TemporaryFileByteSource.OpenReadAndDelete(dmgPath));
+        }
+        catch (Exception ex)
+        {
+            TryDeleteFile(dmgPath);
+            return Result.Failure<IByteSource>(ex.Message);
         }
         finally
         {
-            if (System.IO.Directory.Exists(tempDir))
+            if (Directory.Exists(tempDir))
             {
-                System.IO.Directory.Delete(tempDir, true);
+                Directory.Delete(tempDir, true);
             }
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
         }
     }
 }

--- a/src/DotnetPackaging.Dmg/TemporaryFileByteSource.cs
+++ b/src/DotnetPackaging.Dmg/TemporaryFileByteSource.cs
@@ -1,0 +1,35 @@
+using System.Reactive.Linq;
+using CSharpFunctionalExtensions;
+using Zafiro.DivineBytes;
+
+namespace DotnetPackaging.Dmg;
+
+internal static class TemporaryFileByteSource
+{
+    public static IByteSource OpenReadAndDelete(string path)
+    {
+        var length = new FileInfo(path).Length;
+        var knownLength = Maybe.From(length);
+        var source = ByteSource.FromStreamFactory(
+            () => File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read),
+            knownLength);
+
+        return ByteSource.FromByteObservable(
+            source.Bytes.Finally(() => TryDelete(path)),
+            knownLength);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+        }
+    }
+}

--- a/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
@@ -1,0 +1,68 @@
+using System.Reactive.Linq;
+using CSharpFunctionalExtensions;
+using FluentAssertions;
+using Zafiro.DivineBytes;
+using Path = System.IO.Path;
+
+namespace DotnetPackaging.Dmg.Tests;
+
+public class DmgPackagerTests
+{
+    [Fact]
+    public async Task Pack_should_preserve_length_and_delete_temp_dmg_after_consumption()
+    {
+        using var tempRoot = new TempDir();
+        var existingTempDmgs = SnapshotTempDmgs();
+        var container = CreateContainer(ByteSource.FromBytes("exe"u8.ToArray()));
+        var metadata = new DmgPackagerMetadata
+        {
+            VolumeName = Maybe.From("Test App"),
+            ExecutableName = Maybe.From("TestApp")
+        };
+
+        var result = await new DmgPackager().Pack(container, metadata);
+        result.IsSuccess.Should().BeTrue();
+
+        var output = Path.Combine(tempRoot.Path, "TestApp.dmg");
+        var write = await result.Value.WriteTo(output);
+
+        result.Value.Length.HasValue.Should().BeTrue();
+        result.Value.Length.Value.Should().Be(new FileInfo(output).Length);
+        write.IsSuccess.Should().BeTrue();
+        NewTempDmgs(existingTempDmgs).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Pack_should_not_leave_temp_dmg_when_container_write_fails()
+    {
+        var existingTempDmgs = SnapshotTempDmgs();
+        var failingSource = ByteSource.FromByteObservable(Observable.Throw<byte[]>(new IOException("boom")));
+        var container = CreateContainer(failingSource);
+
+        var result = await new DmgPackager().Pack(container, new DmgPackagerMetadata());
+
+        result.IsFailure.Should().BeTrue();
+        NewTempDmgs(existingTempDmgs).Should().BeEmpty();
+    }
+
+    private static IContainer CreateContainer(IByteSource source)
+    {
+        return new RootContainer(
+            new[] { new NamedByteSource("TestApp", source) },
+            Enumerable.Empty<INamedContainer>());
+    }
+
+    private static HashSet<string> SnapshotTempDmgs()
+    {
+        return Directory
+            .EnumerateFiles(Path.GetTempPath(), "dp-dmg-*.dmg")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> NewTempDmgs(HashSet<string> existing)
+    {
+        return Directory
+            .EnumerateFiles(Path.GetTempPath(), "dp-dmg-*.dmg")
+            .Where(path => !existing.Contains(path));
+    }
+}


### PR DESCRIPTION
## Summary
- wrap generated temporary DMG files in an owning byte source that deletes the temp image after consumption
- preserve `IByteSource.Length` from the temp file metadata without buffering or forcing seekability
- clean up partial temp images when packaging fails before a byte source is returned

## Validation
- dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj --filter DmgPackagerTests
- dotnet build DotnetPackaging.sln

Closes #177