### PR TITLE
[codex] Fix HFS file count for DMG symlinks

### DIFF
--- a/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
@@ -156,7 +156,7 @@ public static class HfsVolumeWriter
             CreateDate = now,
             ModifyDate = now,
             CheckedDate = now,
-            FileCount = fileCount + (uint)symlinkDataList.Count,
+            FileCount = fileCount,
             FolderCount = folderCount, // Remove +1 as fsck counts 13 matching folderCount
             BlockSize = blockSize,
             TotalBlocks = totalBlocks,

--- a/src/DotnetPackaging.Dmg/Verification/DmgVerifier.cs
+++ b/src/DotnetPackaging.Dmg/Verification/DmgVerifier.cs
@@ -43,7 +43,13 @@ public static class DmgVerifier
                 return Result.Failure<string>("UDIF detected but HFS+ signature not found");
             }
 
-            return Result.Success($"UDIF DMG structural-only validation OK (runs={udif.Runs.Count}, sectors={udif.Trailer.SectorCount})");
+            var hfsVerification = HfsPlusVerifier.Verify(dataFork);
+            if (hfsVerification.IsFailure)
+            {
+                return Result.Failure<string>(hfsVerification.Error);
+            }
+
+            return Result.Success($"UDIF DMG OK (runs={udif.Runs.Count}, sectors={udif.Trailer.SectorCount}, files={hfsVerification.Value.FileCount})");
         }
         catch (Exception ex) when (ex is InvalidDataException || ex is IOException)
         {

--- a/src/DotnetPackaging.Dmg/Verification/HfsPlusVerifier.cs
+++ b/src/DotnetPackaging.Dmg/Verification/HfsPlusVerifier.cs
@@ -1,0 +1,219 @@
+using System.Buffers.Binary;
+using CSharpFunctionalExtensions;
+
+namespace DotnetPackaging.Dmg.Verification;
+
+internal static class HfsPlusVerifier
+{
+    private const int VolumeHeaderOffset = 1024;
+    private const int VolumeHeaderSize = 512;
+    private const ushort HfsPlusSignature = 0x482B;
+    private const int FileCountOffset = 32;
+    private const int BlockSizeOffset = 40;
+    private const int CatalogFileOffset = 272;
+    private const int ForkDataLogicalSizeOffset = 0;
+    private const int ForkDataTotalBlocksOffset = 12;
+    private const int ForkDataFirstExtentOffset = 16;
+    private const int ExtentStartBlockOffset = 0;
+    private const int ExtentBlockCountOffset = 4;
+    private const int NodeDescriptorSize = 14;
+    private const byte LeafNodeKind = 0xFF;
+    private const ushort CatalogFileRecordType = 0x0002;
+
+    public static Result<HfsPlusVerification> Verify(byte[] volume)
+    {
+        try
+        {
+            if (volume.Length < VolumeHeaderOffset + VolumeHeaderSize)
+            {
+                return Result.Failure<HfsPlusVerification>("HFS+ payload is too small");
+            }
+
+            var header = volume.AsSpan(VolumeHeaderOffset, VolumeHeaderSize);
+            var signature = BinaryPrimitives.ReadUInt16BigEndian(header);
+            if (signature != HfsPlusSignature)
+            {
+                return Result.Failure<HfsPlusVerification>("HFS+ signature not found");
+            }
+
+            var headerFileCount = BinaryPrimitives.ReadUInt32BigEndian(header[FileCountOffset..]);
+            var blockSize = BinaryPrimitives.ReadUInt32BigEndian(header[BlockSizeOffset..]);
+            if (blockSize == 0)
+            {
+                return Result.Failure<HfsPlusVerification>("HFS+ block size is zero");
+            }
+
+            if (blockSize > int.MaxValue)
+            {
+                return Result.Failure<HfsPlusVerification>("HFS+ block size is too large");
+            }
+
+            var catalogFork = header[CatalogFileOffset..];
+            var catalogLogicalSize = BinaryPrimitives.ReadUInt64BigEndian(catalogFork[ForkDataLogicalSizeOffset..]);
+            var catalogTotalBlocks = BinaryPrimitives.ReadUInt32BigEndian(catalogFork[ForkDataTotalBlocksOffset..]);
+            var firstExtent = catalogFork[ForkDataFirstExtentOffset..];
+            var catalogStartBlock = BinaryPrimitives.ReadUInt32BigEndian(firstExtent[ExtentStartBlockOffset..]);
+            var catalogExtentBlocks = BinaryPrimitives.ReadUInt32BigEndian(firstExtent[ExtentBlockCountOffset..]);
+
+            if (catalogLogicalSize == 0 || catalogTotalBlocks == 0 || catalogExtentBlocks == 0)
+            {
+                return Result.Failure<HfsPlusVerification>("HFS+ catalog file is empty");
+            }
+
+            var catalogOffset = checked((long)catalogStartBlock * blockSize);
+            var catalogExtentLength = checked((long)catalogExtentBlocks * blockSize);
+            if (catalogOffset < 0 || catalogOffset >= volume.Length || catalogOffset + catalogExtentLength > volume.Length)
+            {
+                return Result.Failure<HfsPlusVerification>("HFS+ catalog extent is outside the payload");
+            }
+
+            var catalogLength = (int)Math.Min(catalogLogicalSize, (ulong)catalogExtentLength);
+            var catalog = volume.AsSpan((int)catalogOffset, catalogLength);
+            var catalogFileRecords = CountCatalogFileRecords(catalog, (int)blockSize);
+            if (catalogFileRecords.IsFailure)
+            {
+                return Result.Failure<HfsPlusVerification>(catalogFileRecords.Error);
+            }
+
+            if (headerFileCount != catalogFileRecords.Value)
+            {
+                return Result.Failure<HfsPlusVerification>($"HFS+ file count mismatch: header={headerFileCount}, catalog={catalogFileRecords.Value}");
+            }
+
+            return Result.Success(new HfsPlusVerification(headerFileCount));
+        }
+        catch (OverflowException)
+        {
+            return Result.Failure<HfsPlusVerification>("HFS+ catalog offsets overflow");
+        }
+    }
+
+    private static Result<uint> CountCatalogFileRecords(ReadOnlySpan<byte> catalog, int headerNodeSize)
+    {
+        var headerRecord = ReadRecord(catalog, nodeOffset: 0, nodeSize: headerNodeSize, recordIndex: 0);
+        if (headerRecord.IsFailure)
+        {
+            return Result.Failure<uint>($"HFS+ catalog header is invalid: {headerRecord.Error}");
+        }
+
+        var bTreeHeader = headerRecord.Value;
+        var bTreeHeaderSpan = bTreeHeader.Span;
+        if (bTreeHeaderSpan.Length < 26)
+        {
+            return Result.Failure<uint>("HFS+ catalog B-tree header is too small");
+        }
+
+        var firstLeafNode = BinaryPrimitives.ReadUInt32BigEndian(bTreeHeaderSpan[10..]);
+        var nodeSize = BinaryPrimitives.ReadUInt16BigEndian(bTreeHeaderSpan[18..]);
+        var totalNodes = BinaryPrimitives.ReadUInt32BigEndian(bTreeHeaderSpan[22..]);
+        if (nodeSize == 0)
+        {
+            return Result.Failure<uint>("HFS+ catalog B-tree node size is zero");
+        }
+
+        if (firstLeafNode == 0)
+        {
+            return Result.Success(0u);
+        }
+
+        uint fileRecords = 0;
+        var currentNode = firstLeafNode;
+        var visited = new HashSet<uint>();
+
+        while (currentNode != 0)
+        {
+            if (!visited.Add(currentNode))
+            {
+                return Result.Failure<uint>("HFS+ catalog leaf chain contains a cycle");
+            }
+
+            if (totalNodes != 0 && currentNode >= totalNodes)
+            {
+                return Result.Failure<uint>($"HFS+ catalog leaf node {currentNode} is outside the B-tree");
+            }
+
+            var nodeOffset = checked((long)currentNode * nodeSize);
+            if (nodeOffset < 0 || nodeOffset + nodeSize > catalog.Length)
+            {
+                return Result.Failure<uint>($"HFS+ catalog leaf node {currentNode} is outside the catalog file");
+            }
+
+            var node = catalog.Slice((int)nodeOffset, nodeSize);
+            if (node[8] != LeafNodeKind)
+            {
+                return Result.Failure<uint>($"HFS+ catalog node {currentNode} is not a leaf node");
+            }
+
+            var recordCount = BinaryPrimitives.ReadUInt16BigEndian(node[10..]);
+            for (var i = 0; i < recordCount; i++)
+            {
+                var record = ReadRecord(catalog, nodeOffset, nodeSize, i);
+                if (record.IsFailure)
+                {
+                    return Result.Failure<uint>($"HFS+ catalog leaf record {i} in node {currentNode} is invalid: {record.Error}");
+                }
+
+                if (IsCatalogFileRecord(record.Value))
+                {
+                    fileRecords++;
+                }
+            }
+
+            currentNode = BinaryPrimitives.ReadUInt32BigEndian(node);
+        }
+
+        return Result.Success(fileRecords);
+    }
+
+    private static Result<ReadOnlyMemory<byte>> ReadRecord(ReadOnlySpan<byte> tree, long nodeOffset, int nodeSize, int recordIndex)
+    {
+        if (nodeSize < NodeDescriptorSize || nodeOffset < 0 || nodeOffset + nodeSize > tree.Length)
+        {
+            return Result.Failure<ReadOnlyMemory<byte>>("node bounds are invalid");
+        }
+
+        var node = tree.Slice((int)nodeOffset, nodeSize);
+        var recordCount = BinaryPrimitives.ReadUInt16BigEndian(node[10..]);
+        if (recordIndex < 0 || recordIndex >= recordCount)
+        {
+            return Result.Failure<ReadOnlyMemory<byte>>("record index is outside the node");
+        }
+
+        var startOffsetIndex = nodeSize - ((recordIndex + 1) * 2);
+        var endOffsetIndex = nodeSize - ((recordIndex + 2) * 2);
+        if (endOffsetIndex < 0)
+        {
+            return Result.Failure<ReadOnlyMemory<byte>>("record offset table is outside the node");
+        }
+
+        var recordStart = BinaryPrimitives.ReadUInt16BigEndian(node[startOffsetIndex..]);
+        var recordEnd = BinaryPrimitives.ReadUInt16BigEndian(node[endOffsetIndex..]);
+        if (recordStart < NodeDescriptorSize || recordEnd < recordStart || recordEnd > nodeSize)
+        {
+            return Result.Failure<ReadOnlyMemory<byte>>("record bounds are invalid");
+        }
+
+        ReadOnlyMemory<byte> record = tree.Slice((int)nodeOffset + recordStart, recordEnd - recordStart).ToArray();
+        return Result.Success(record);
+    }
+
+    private static bool IsCatalogFileRecord(ReadOnlyMemory<byte> recordMemory)
+    {
+        var record = recordMemory.Span;
+        if (record.Length < 4)
+        {
+            return false;
+        }
+
+        var keyLength = BinaryPrimitives.ReadUInt16BigEndian(record);
+        var recordTypeOffset = 2 + keyLength;
+        if (recordTypeOffset + 2 > record.Length)
+        {
+            return false;
+        }
+
+        return BinaryPrimitives.ReadUInt16BigEndian(record[recordTypeOffset..]) == CatalogFileRecordType;
+    }
+}
+
+internal sealed record HfsPlusVerification(uint FileCount);

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -87,6 +87,24 @@ public class DmgHfsBuilderTests
     }
 
     [Fact]
+    public async Task Hfs_file_count_includes_applications_symlink_once()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+
+        var outDmg = Path.Combine(tempRoot.Path, "Test.dmg");
+        await DmgHfsBuilder.Create(publish, outDmg, "Test App", addApplicationsSymlink: true);
+
+        var data = await ExtractVolumeBytes(outDmg);
+        var fileCount = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(1024 + 32, 4));
+
+        fileCount.Should().Be(6);
+    }
+
+    [Fact]
     public async Task Volume_name_is_sanitized_correctly()
     {
         using var tempRoot = new TempDir();

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using DotnetPackaging.Dmg;
+using DotnetPackaging.Dmg.Verification;
 using DotnetPackaging.Formats.Dmg.Udif;
 using FluentAssertions;
 using Path = System.IO.Path;
@@ -105,6 +106,48 @@ public class DmgHfsBuilderTests
     }
 
     [Fact]
+    public async Task Dmg_verify_accepts_matching_hfs_file_count()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+
+        var outDmg = Path.Combine(tempRoot.Path, "Test.dmg");
+        await DmgHfsBuilder.Create(publish, outDmg, "Test App", addApplicationsSymlink: true);
+
+        var result = await DmgVerifier.Verify(outDmg);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Dmg_verify_rejects_mismatched_hfs_file_count()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+
+        var outDmg = Path.Combine(tempRoot.Path, "Test.dmg");
+        await DmgHfsBuilder.Create(publish, outDmg, "Test App", addApplicationsSymlink: true);
+
+        var volume = await ExtractVolumeBytes(outDmg);
+        var fileCount = BinaryPrimitives.ReadUInt32BigEndian(volume.AsSpan(1024 + 32, 4));
+        BinaryPrimitives.WriteUInt32BigEndian(volume.AsSpan(1024 + 32, 4), fileCount + 1);
+
+        var corruptDmg = Path.Combine(tempRoot.Path, "Corrupt.dmg");
+        await WriteVolumeBytesToDmg(volume, corruptDmg);
+
+        var result = await DmgVerifier.Verify(corruptDmg);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("HFS+ file count mismatch");
+    }
+
+    [Fact]
     public async Task Volume_name_is_sanitized_correctly()
     {
         using var tempRoot = new TempDir();
@@ -168,5 +211,12 @@ public class DmgHfsBuilderTests
     {
         var udif = await UdifImage.Load(dmgPath);
         return await udif.ExtractDataFork();
+    }
+
+    private static async Task WriteVolumeBytesToDmg(byte[] volume, string dmgPath)
+    {
+        await using var output = File.Create(dmgPath);
+        using var input = new MemoryStream(volume);
+        new UdifWriter { CompressionType = CompressionType.Raw }.Create(input, output);
     }
 }

--- a/test/DotnetPackaging.E2E.Tests/PackagingTests.cs
+++ b/test/DotnetPackaging.E2E.Tests/PackagingTests.cs
@@ -89,7 +89,7 @@ public class PackagingTests : IDisposable
     }
 
     [Fact]
-    public async Task Can_create_Dmg()
+    public async Task Can_create_and_verify_Dmg()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
@@ -104,6 +104,7 @@ public class PackagingTests : IDisposable
         // Let's use osx-x64 for DMG.
         await ExecutePackagingCommand("dmg", output, "--arch x64");
         File.Exists(output).Should().BeTrue();
+        await ExecuteDmgVerifyCommand(output);
     }
 
     private async Task ExecutePackagingCommand(string format, string outputPath, string extraArgs)
@@ -112,6 +113,15 @@ public class PackagingTests : IDisposable
         await Execute(
             "dotnet",
             $"run --project \"{toolProject}\" -- {format} from-project --project \"{projectPath}\" --output \"{outputPath}\" {extraArgs}",
+            repoRoot);
+    }
+
+    private async Task ExecuteDmgVerifyCommand(string dmgPath)
+    {
+        var toolProject = Path.Combine(repoRoot, "src", "DotnetPackaging.Tool", "DotnetPackaging.Tool.csproj");
+        await Execute(
+            "dotnet",
+            $"run --project \"{toolProject}\" -- dmg verify --file \"{dmgPath}\"",
             repoRoot);
     }
 


### PR DESCRIPTION
## Summary
- stop double-counting HFS symlinks in the volume header file count
- add a regression test for DMGs that include the default Applications symlink

## Validation
- dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj --filter Hfs_file_count_includes_applications_symlink_once
- dotnet build DotnetPackaging.sln

Closes #175