### PR TITLE
feat(dmg): support custom Info.plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Every format command offers two subcommands:
 
 Run `dotnetpackager <command> --help` to see the full list of shared options (`--application-name`, `--comment`, `--homepage`, `--keywords`, `--icon`, `--is-terminal`, etc.).
 
+DMG packages auto-generate an `.app/Contents/Info.plist` when the published directory does not already contain an `.app` bundle. By default the generated plist uses CLI/project metadata such as `--application-name`, `--appId`, `--version` and `--executable-name`. To take full control, pass `--info-plist ./Info.plist` to `dmg from-directory` or `dmg from-project`; that file has precedence over generated metadata. If no CLI plist is supplied, a root `Info.plist` next to the publish output or project is used before falling back to generated metadata.
+
 ### Examples
 Build an AppImage from a published directory:
 ```bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,14 @@ steps:
       $ErrorActionPreference = 'Stop'
       dotnet tool install --global GitVersion.Tool --version 6.*
       $env:PATH += ";$env:USERPROFILE\\.dotnet\\tools"
-      $json = dotnet-gitversion /output json
-      if (-not $json) { throw 'GitVersion returned no output' }
+      $raw = dotnet-gitversion /output json 2>&1 | Out-String
+      if (-not $raw) { throw 'GitVersion returned no output' }
+      $start = $raw.IndexOf('{')
+      $end = $raw.LastIndexOf('}')
+      if ($start -lt 0 -or $end -lt $start) {
+        throw "GitVersion did not emit a JSON object. Output: $raw"
+      }
+      $json = $raw.Substring($start, $end - $start + 1)
       $gv = $json | ConvertFrom-Json
       # Use strictly MajorMinorPatch for package Version (no prerelease/metadata)
       $version = $gv.MajorMinorPatch

--- a/src/DotnetPackaging.Dmg/DmgHfsBuilder.cs
+++ b/src/DotnetPackaging.Dmg/DmgHfsBuilder.cs
@@ -38,7 +38,10 @@ internal static class DmgHfsBuilder
         bool addApplicationsSymlink = false, 
         bool includeDefaultLayout = true, 
         Maybe<IIcon> icon = default,
-        string? executableName = null)
+        string? executableName = null,
+        Maybe<IByteSource> infoPlist = default,
+        Maybe<string> bundleIdentifier = default,
+        Maybe<string> bundleVersion = default)
     {
         var builder = HfsVolumeBuilder.Create(SanitizeVolumeName(volumeName));
 
@@ -75,15 +78,15 @@ internal static class DmgHfsBuilder
             // Add all files to MacOS folder
             await AddDirectoryContents(macOsDir, sourceFolder, 
                 path => path.EndsWith(".app", StringComparison.OrdinalIgnoreCase) || 
-                        path.EndsWith(".icns", StringComparison.OrdinalIgnoreCase));
+                        path.EndsWith(".icns", StringComparison.OrdinalIgnoreCase) ||
+                        IsRootInfoPlist(sourceFolder, path));
 
             // Handle icon
             var appIcon = await PrepareAppIcon(sourceFolder, resourcesDir, icon);
 
             // Generate Info.plist
             var exeName = executableName ?? GuessExecutableName(sourceFolder, volumeName);
-            var plist = GenerateMinimalPlist(volumeName, exeName, appIcon.HasValue ? appIcon.Value : null);
-            contentsDir.AddFile("Info.plist", Encoding.UTF8.GetBytes(plist));
+            await AddInfoPlist(contentsDir, sourceFolder, infoPlist, volumeName, exeName, appIcon, bundleIdentifier, bundleVersion);
             contentsDir.AddFile("PkgInfo", Encoding.ASCII.GetBytes("APPL????"));
         }
 
@@ -155,6 +158,61 @@ internal static class DmgHfsBuilder
             var fileBytes = await File.ReadAllBytesAsync(file);
             target.AddFile(fileName, fileBytes);
         }
+    }
+
+    private static async Task AddInfoPlist(
+        HfsDirectory contentsDir,
+        string sourceFolder,
+        Maybe<IByteSource> providedInfoPlist,
+        string volumeName,
+        string executableName,
+        Maybe<string> appIcon,
+        Maybe<string> bundleIdentifier,
+        Maybe<string> bundleVersion)
+    {
+        var sourceInfoPlistPath = FindSourceInfoPlist(sourceFolder);
+        var sourceInfoPlist = sourceInfoPlistPath.HasValue
+            ? Maybe<IByteSource>.From(FileByteSource.OpenRead(sourceInfoPlistPath.Value))
+            : Maybe<IByteSource>.None;
+        var customInfoPlist = providedInfoPlist.Or(sourceInfoPlist);
+
+        if (customInfoPlist.HasValue)
+        {
+            await AddFile(contentsDir, "Info.plist", customInfoPlist.Value);
+            return;
+        }
+
+        var plist = GenerateMinimalPlist(
+            volumeName,
+            executableName,
+            appIcon.HasValue ? appIcon.Value : null,
+            bundleIdentifier,
+            bundleVersion);
+        contentsDir.AddFile("Info.plist", Encoding.UTF8.GetBytes(plist));
+    }
+
+    private static async Task AddFile(HfsDirectory target, string name, IByteSource source)
+    {
+        if (source.Length.HasValue)
+        {
+            target.AddFile(name, source, source.Length.Value);
+            return;
+        }
+
+        var chunks = await source.Bytes.ToList();
+        target.AddFile(name, chunks.SelectMany(bytes => bytes).ToArray());
+    }
+
+    private static Maybe<string> FindSourceInfoPlist(string sourceFolder)
+    {
+        var path = Path.Combine(sourceFolder, "Info.plist");
+        return File.Exists(path) ? Maybe.From(path) : Maybe<string>.None;
+    }
+
+    private static bool IsRootInfoPlist(string sourceFolder, string path)
+    {
+        return string.Equals(Path.GetFileName(path), "Info.plist", StringComparison.OrdinalIgnoreCase)
+               && string.Equals(Path.GetDirectoryName(path), sourceFolder, StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<Maybe<string>> PrepareAppIcon(string sourceFolder, HfsDirectory resources, Maybe<IIcon> providedIcon)
@@ -295,9 +353,16 @@ internal static class DmgHfsBuilder
         return match;
     }
 
-    private static string GenerateMinimalPlist(string displayName, string executable, string? iconName)
+    private static string GenerateMinimalPlist(
+        string displayName,
+        string executable,
+        string? iconName,
+        Maybe<string> bundleIdentifier = default,
+        Maybe<string> bundleVersion = default)
     {
-        var identifier = $"com.{SanitizeBundleName(displayName).Trim('-').Trim('_').ToLowerInvariant()}";
+        var fallbackIdentifier = $"com.{SanitizeBundleName(displayName).Trim('-').Trim('_').ToLowerInvariant()}";
+        var identifier = bundleIdentifier.GetValueOrDefault(fallbackIdentifier);
+        var version = bundleVersion.GetValueOrDefault("1.0");
         return $"""
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -308,9 +373,9 @@ internal static class DmgHfsBuilder
     <key>CFBundleIdentifier</key>
     <string>{System.Security.SecurityElement.Escape(identifier)}</string>
     <key>CFBundleVersion</key>
-    <string>1.0</string>
+    <string>{System.Security.SecurityElement.Escape(version)}</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>{System.Security.SecurityElement.Escape(version)}</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/src/DotnetPackaging.Dmg/DmgPackager.cs
+++ b/src/DotnetPackaging.Dmg/DmgPackager.cs
@@ -48,7 +48,10 @@ public sealed class DmgPackager
                 metadata.AddApplicationsSymlink.GetValueOrDefault(true),
                 metadata.IncludeDefaultLayout.GetValueOrDefault(true),
                 metadata.Icon,
-                executableName);
+                executableName,
+                metadata.InfoPlist,
+                metadata.BundleIdentifier,
+                metadata.BundleVersion);
 
             return Result.Success<IByteSource>(TemporaryFileByteSource.OpenReadAndDelete(dmgPath));
         }
@@ -92,4 +95,7 @@ internal class DmgOptions
     public bool AddApplicationsSymlink { get; set; } = true;
     public bool IncludeDefaultLayout { get; set; } = true;
     public Maybe<IIcon> Icon { get; set; } = Maybe<IIcon>.None;
+    public Maybe<IByteSource> InfoPlist { get; set; } = Maybe<IByteSource>.None;
+    public Maybe<string> BundleIdentifier { get; set; } = Maybe<string>.None;
+    public Maybe<string> BundleVersion { get; set; } = Maybe<string>.None;
 }

--- a/src/DotnetPackaging.Dmg/DmgPackagerExtensions.cs
+++ b/src/DotnetPackaging.Dmg/DmgPackagerExtensions.cs
@@ -84,16 +84,20 @@ public static class DmgPackagerExtensions
         var projectMetadata = ProjectMetadataReader.TryRead(projectFile, logger);
         var inferred = ProjectMetadataDefaults.InferExecutableName(projectMetadata, projectFile);
 
-        return ResolveFromProject(source, inferred);
+        return ResolveFromProject(source, inferred, projectMetadata, projectFile.Directory);
     }
 
     private static DmgPackagerMetadata ResolveFromProject(DmgPackagerMetadata source, ProjectPackagingContext context)
     {
         var inferred = context.InferExecutableName();
-        return ResolveFromProject(source, inferred);
+        return ResolveFromProject(source, inferred, context.ProjectMetadata, context.ProjectFile.Directory);
     }
 
-    private static DmgPackagerMetadata ResolveFromProject(DmgPackagerMetadata source, Maybe<string> inferred)
+    private static DmgPackagerMetadata ResolveFromProject(
+        DmgPackagerMetadata source,
+        Maybe<string> inferred,
+        Maybe<ProjectMetadata> projectMetadata = default,
+        DirectoryInfo? projectDirectory = null)
     {
         return new DmgPackagerMetadata
         {
@@ -102,7 +106,23 @@ public static class DmgPackagerExtensions
             Compress = source.Compress,
             AddApplicationsSymlink = source.AddApplicationsSymlink,
             IncludeDefaultLayout = source.IncludeDefaultLayout,
-            Icon = source.Icon
+            Icon = source.Icon,
+            InfoPlist = source.InfoPlist.Or(() => FindProjectInfoPlist(projectDirectory)),
+            BundleIdentifier = source.BundleIdentifier.Or(projectMetadata.Bind(metadata => metadata.PackageId)),
+            BundleVersion = source.BundleVersion.Or(projectMetadata.Bind(metadata => metadata.Version))
         };
+    }
+
+    private static Maybe<IByteSource> FindProjectInfoPlist(DirectoryInfo? projectDirectory)
+    {
+        if (projectDirectory == null)
+        {
+            return Maybe<IByteSource>.None;
+        }
+
+        var path = System.IO.Path.Combine(projectDirectory.FullName, "Info.plist");
+        return File.Exists(path)
+            ? Maybe<IByteSource>.From(FileByteSource.OpenRead(path))
+            : Maybe<IByteSource>.None;
     }
 }

--- a/src/DotnetPackaging.Dmg/DmgPackagerMetadata.cs
+++ b/src/DotnetPackaging.Dmg/DmgPackagerMetadata.cs
@@ -1,5 +1,6 @@
 using CSharpFunctionalExtensions;
 using DotnetPackaging;
+using Zafiro.DivineBytes;
 
 namespace DotnetPackaging.Dmg;
 
@@ -11,4 +12,7 @@ public sealed class DmgPackagerMetadata
     public Maybe<bool> AddApplicationsSymlink { get; set; } = Maybe<bool>.None;
     public Maybe<bool> IncludeDefaultLayout { get; set; } = Maybe<bool>.None;
     public Maybe<IIcon> Icon { get; set; } = Maybe<IIcon>.None;
+    public Maybe<IByteSource> InfoPlist { get; set; } = Maybe<IByteSource>.None;
+    public Maybe<string> BundleIdentifier { get; set; } = Maybe<string>.None;
+    public Maybe<string> BundleVersion { get; set; } = Maybe<string>.None;
 }

--- a/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.IO;
 using CSharpFunctionalExtensions;
 using DotnetPackaging;
@@ -23,6 +24,7 @@ public static class DmgCommand
             Description = "Add a default Finder layout (background image, Applications link positioning) when none is provided"
         };
         defaultLayoutOption.DefaultValueFactory = _ => true;
+        var infoPlistOption = CreateInfoPlistOption();
 
         var commands = CommandFactory.CreateCommand(
             "dmg",
@@ -31,8 +33,10 @@ public static class DmgCommand
             CreateDmg,
             "Create a macOS disk image (.dmg) with a native HFS+ payload wrapped in UDIF (DMG) format.",
             defaultLayoutOption,
-            null,
+            (options, parseResult) => options.InfoPlist = Maybe.From(parseResult.GetValue(infoPlistOption)),
             "pack-dmg");
+        commands.Root.Add(infoPlistOption);
+        commands.FromDirectory.Add(infoPlistOption);
 
         AddDmgFromProjectSubcommand(commands.Root);
 
@@ -79,6 +83,9 @@ public static class DmgCommand
             VolumeName = options.Name.Or(Maybe.From(inputDir.Name)),
             ExecutableName = options.ExecutableName,
             IncludeDefaultLayout = options.UseDefaultLayout,
+            InfoPlist = options.InfoPlist,
+            BundleIdentifier = options.Id,
+            BundleVersion = options.Version,
             Icon = options.Icon,
             Compress = Maybe.From(true),
             AddApplicationsSymlink = Maybe.From(true)
@@ -98,6 +105,7 @@ public static class DmgCommand
         compress.DefaultValueFactory = _ => true;
         var defaultLayoutOption = new Option<bool>("--with-default-layout") { Description = "Add a default Finder layout (background image, Applications link positioning) when none is provided" };
         defaultLayoutOption.DefaultValueFactory = _ => true;
+        var infoPlistOption = CreateInfoPlistOption();
 
         var binder = metadata.CreateBinder(defaultLayoutOption);
 
@@ -106,6 +114,7 @@ public static class DmgCommand
         metadata.AddTo(fromProject);
         fromProject.Add(compress);
         fromProject.Add(defaultLayoutOption);
+        fromProject.Add(infoPlistOption);
 
         fromProject.SetAction(async parseResult =>
         {
@@ -117,6 +126,7 @@ public static class DmgCommand
             var opt = binder.Bind(parseResult);
             var ridVal = parseResult.GetValue(project.Arch);
             var compressVal = parseResult.GetValue(compress);
+            var infoPlist = parseResult.GetValue(infoPlistOption);
             var useDefaultLayout = opt.UseDefaultLayout.GetValueOrDefault(true);
             var logger = Log.ForContext("command", "dmg-from-project");
 
@@ -133,6 +143,9 @@ public static class DmgCommand
                     dmgOpt.Compress = Maybe.From(compressVal);
                     dmgOpt.IncludeDefaultLayout = Maybe.From(useDefaultLayout);
                     dmgOpt.Icon = icon;
+                    dmgOpt.InfoPlist = Maybe.From(infoPlist);
+                    dmgOpt.BundleIdentifier = opt.Id;
+                    dmgOpt.BundleVersion = opt.Version;
                 },
                 pub =>
                 {
@@ -152,6 +165,34 @@ public static class DmgCommand
         });
 
         dmgCommand.Add(fromProject);
+    }
+
+    private static Option<IByteSource?> CreateInfoPlistOption()
+    {
+        var option = new Option<IByteSource?>("--info-plist")
+        {
+            Required = false,
+            Description = "Path to a custom Info.plist to embed in the generated .app bundle"
+        };
+        option.CustomParser = ParseInfoPlist;
+        return option;
+    }
+
+    private static IByteSource? ParseInfoPlist(ArgumentResult result)
+    {
+        if (result.Tokens.Count == 0)
+        {
+            return null;
+        }
+
+        var path = result.Tokens[0].Value;
+        if (!File.Exists(path))
+        {
+            result.AddError($"Invalid Info.plist '{path}': File not found");
+            return null;
+        }
+
+        return FileByteSource.OpenRead(path);
     }
 
     private static async Task<Maybe<IIcon>> ResolveIcon(Options options, DirectoryInfo projectDirectory, ILogger logger)

--- a/src/DotnetPackaging/Options.cs
+++ b/src/DotnetPackaging/Options.cs
@@ -1,4 +1,6 @@
-﻿namespace DotnetPackaging;
+﻿using Zafiro.DivineBytes;
+
+namespace DotnetPackaging;
 
 public class Options
 {
@@ -18,6 +20,7 @@ public class Options
     public Maybe<string> ExecutableName { get; set; }
     public Maybe<bool> IsTerminal { get; set; }
     public Maybe<bool> UseDefaultLayout { get; set; }
+    public Maybe<IByteSource> InfoPlist { get; set; }
     public Maybe<bool> IsService { get; set; }
     public Maybe<ServiceType> ServiceType { get; set; }
     public Maybe<RestartPolicy> ServiceRestart { get; set; }

--- a/src/DotnetPackaging/ProjectMetadata.cs
+++ b/src/DotnetPackaging/ProjectMetadata.cs
@@ -12,6 +12,8 @@ public sealed record ProjectMetadata(
     Maybe<string> Copyright,
     Maybe<string> PackageLicenseExpression,
     Maybe<string> PackageProjectUrl,
+    Maybe<string> PackageId,
+    Maybe<string> Version,
     Maybe<string> RepositoryUrl,
     Maybe<string> AssemblyName,
     Maybe<string> AssemblyTitle,
@@ -21,7 +23,7 @@ public static class ProjectMetadataReader
 {
     private static readonly string[] PropertiesToRead = new[]
     {
-        "Product", "Company", "Description", "Authors", "Copyright", "PackageLicenseExpression", "PackageProjectUrl", "RepositoryUrl", "AssemblyName", "AssemblyTitle", "OutputType"
+        "Product", "Company", "Description", "Authors", "Copyright", "PackageLicenseExpression", "PackageProjectUrl", "PackageId", "Version", "RepositoryUrl", "AssemblyName", "AssemblyTitle", "OutputType"
     };
 
     public static Result<ProjectMetadata> Read(FileInfo projectFile)
@@ -102,12 +104,14 @@ public static class ProjectMetadataReader
             var copyright = values.GetValueOrDefault("Copyright");
             var license = values.GetValueOrDefault("PackageLicenseExpression");
             var url = values.GetValueOrDefault("PackageProjectUrl");
+            var packageId = values.GetValueOrDefault("PackageId");
+            var version = values.GetValueOrDefault("Version");
             var repo = values.GetValueOrDefault("RepositoryUrl");
             var assemblyName = values.GetValueOrDefault("AssemblyName");
             var assemblyTitle = values.GetValueOrDefault("AssemblyTitle");
             var outputType = values.GetValueOrDefault("OutputType");
 
-            return Result.Success(new ProjectMetadata(product, company, description, authors, copyright, license, url, repo, assemblyName, assemblyTitle, outputType));
+            return Result.Success(new ProjectMetadata(product, company, description, authors, copyright, license, url, packageId, version, repo, assemblyName, assemblyTitle, outputType));
         }
         catch (Exception ex)
         {
@@ -126,11 +130,13 @@ public static class ProjectMetadataReader
         var copyright = ReadProperty(document, "Copyright");
         var license = ReadProperty(document, "PackageLicenseExpression");
         var url = ReadProperty(document, "PackageProjectUrl");
+        var packageId = ReadProperty(document, "PackageId");
+        var version = ReadProperty(document, "Version");
         var repo = ReadProperty(document, "RepositoryUrl");
         var assemblyName = ReadProperty(document, "AssemblyName");
         var assemblyTitle = ReadProperty(document, "AssemblyTitle");
         var outputType = ReadProperty(document, "OutputType");
-        return new ProjectMetadata(product, company, description, authors, copyright, license, url, repo, assemblyName, assemblyTitle, outputType);
+        return new ProjectMetadata(product, company, description, authors, copyright, license, url, packageId, version, repo, assemblyName, assemblyTitle, outputType);
     }
 
     private static Dictionary<string, Maybe<string>> ParseMsbuildOutput(string output, IEnumerable<string> propertyNames)

--- a/src/DotnetPackaging/ProjectMetadataDefaults.cs
+++ b/src/DotnetPackaging/ProjectMetadataDefaults.cs
@@ -39,6 +39,14 @@ public static class ProjectMetadataDefaults
             {
                 metadata.Company.Execute(c => resolved.WithVendor(c));
             }
+            if (resolved.Id.HasNoValue)
+            {
+                metadata.PackageId.Execute(id => resolved.WithId(id));
+            }
+            if (resolved.Version.HasNoValue)
+            {
+                metadata.Version.Execute(version => resolved.WithVersion(version));
+            }
             if (resolved.Url.HasNoValue)
             {
                 metadata.PackageProjectUrl

--- a/test/DotnetPackaging.Deb.Tests/ProjectPackagingContextTests.cs
+++ b/test/DotnetPackaging.Deb.Tests/ProjectPackagingContextTests.cs
@@ -23,6 +23,8 @@ public class ProjectPackagingContextTests
                 <Authors>Sample Authors</Authors>
                 <PackageLicenseExpression>MIT</PackageLicenseExpression>
                 <PackageProjectUrl>https://example.com/sample</PackageProjectUrl>
+                <PackageId>com.example.sample</PackageId>
+                <Version>4.5.6</Version>
               </PropertyGroup>
             </Project>
             """);
@@ -38,6 +40,8 @@ public class ProjectPackagingContextTests
             options.Description.GetValueOrDefault().Should().Be("Sample description");
             options.Maintainer.GetValueOrDefault().Should().Be("Sample Authors");
             options.Vendor.GetValueOrDefault().Should().Be("Sample Company");
+            options.Id.GetValueOrDefault().Should().Be("com.example.sample");
+            options.Version.GetValueOrDefault().Should().Be("4.5.6");
             options.License.GetValueOrDefault().Should().Be("MIT");
             options.Url.GetValueOrDefault()?.ToString().Should().Be("https://example.com/sample");
             options.IsTerminal.GetValueOrDefault().Should().BeTrue();

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -1,7 +1,11 @@
 using System.Buffers.Binary;
+using System.Reactive.Linq;
+using System.Text;
+using CSharpFunctionalExtensions;
 using DotnetPackaging.Dmg;
 using DotnetPackaging.Formats.Dmg.Udif;
 using FluentAssertions;
+using Zafiro.DivineBytes;
 using Path = System.IO.Path;
 
 namespace DotnetPackaging.Dmg.Tests;
@@ -65,6 +69,147 @@ public class DmgHfsBuilderTests
         var data = await ExtractVolumeBytes(outDmg);
         data.Length.Should().BeGreaterThan(1000, "dmg should contain app bundle content");
         BinaryPrimitives.ReadUInt16BigEndian(data.AsSpan(1024, 2)).Should().Be(0x482B);
+    }
+
+    [Fact]
+    public async Task Uses_custom_info_plist_when_wrapping_publish_output()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+        var plist = """
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.customplist</string>
+    <key>CFBundleExecutable</key>
+    <string>TestApp</string>
+  </dict>
+</plist>
+""";
+
+        var outDmg = Path.Combine(tempRoot.Path, "Custom.dmg");
+        await DmgHfsBuilder.Create(
+            publish,
+            outDmg,
+            "Test App",
+            infoPlist: Maybe.From(ByteSource.FromString(plist)));
+
+        var data = await ExtractVolumeBytes(outDmg);
+        Encoding.UTF8.GetString(data).Should().Contain("com.example.customplist");
+    }
+
+    [Fact]
+    public async Task Custom_info_plist_with_known_length_is_consumed_once()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+        var plistBytes = """
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleExecutable</key><string>TestApp</string></dict></plist>
+"""u8.ToArray();
+        var subscriptions = 0;
+        var plistSource = ByteSource.FromByteObservable(
+            Observable.Defer(() =>
+            {
+                subscriptions++;
+                return Observable.Return(plistBytes);
+            }),
+            plistBytes.LongLength);
+
+        var outDmg = Path.Combine(tempRoot.Path, "Custom.dmg");
+        await DmgHfsBuilder.Create(
+            publish,
+            outDmg,
+            "Test App",
+            infoPlist: Maybe.From(plistSource));
+
+        subscriptions.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Custom_info_plist_without_known_length_is_consumed_once()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+        var plistBytes = """
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.example.unknownlength</string></dict></plist>
+"""u8.ToArray();
+        var subscriptions = 0;
+        var plistSource = ByteSource.FromByteObservable(
+            Observable.Defer(() =>
+            {
+                subscriptions++;
+                return Observable.Return(plistBytes);
+            }));
+
+        var outDmg = Path.Combine(tempRoot.Path, "Custom.dmg");
+        await DmgHfsBuilder.Create(
+            publish,
+            outDmg,
+            "Test App",
+            infoPlist: Maybe.From(plistSource));
+
+        var data = await ExtractVolumeBytes(outDmg);
+        Encoding.UTF8.GetString(data).Should().Contain("com.example.unknownlength");
+        subscriptions.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Uses_source_info_plist_when_wrapping_publish_output()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+        await File.WriteAllTextAsync(
+            Path.Combine(publish, "Info.plist"),
+            """
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.example.sourceplist</string></dict></plist>
+""");
+
+        var outDmg = Path.Combine(tempRoot.Path, "Source.dmg");
+        await DmgHfsBuilder.Create(publish, outDmg, "Test App");
+
+        var data = await ExtractVolumeBytes(outDmg);
+        Encoding.UTF8.GetString(data).Should().Contain("com.example.sourceplist");
+    }
+
+    [Fact]
+    public async Task Generated_info_plist_uses_metadata_when_no_custom_plist_is_supplied()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        await File.WriteAllTextAsync(Path.Combine(publish, "TestApp"), "exe");
+
+        var outDmg = Path.Combine(tempRoot.Path, "Metadata.dmg");
+        await DmgHfsBuilder.Create(
+            publish,
+            outDmg,
+            "Test App",
+            executableName: "TestApp",
+            bundleIdentifier: Maybe.From("com.example.metadata"),
+            bundleVersion: Maybe.From("2.3.4"));
+
+        var data = await ExtractVolumeBytes(outDmg);
+        var text = Encoding.UTF8.GetString(data);
+        text.Should().Contain("com.example.metadata");
+        text.Should().Contain("2.3.4");
     }
 
     [Fact]

--- a/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
@@ -1,5 +1,7 @@
 using System.Reactive.Linq;
+using System.Text;
 using CSharpFunctionalExtensions;
+using DotnetPackaging.Formats.Dmg.Udif;
 using FluentAssertions;
 using Zafiro.DivineBytes;
 using Path = System.IO.Path;
@@ -45,6 +47,57 @@ public class DmgPackagerTests
         NewTempDmgs(existingTempDmgs).Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task Pack_should_embed_custom_info_plist()
+    {
+        using var tempRoot = new TempDir();
+        var container = CreateContainer(ByteSource.FromBytes("exe"u8.ToArray()));
+        var metadata = new DmgPackagerMetadata
+        {
+            VolumeName = Maybe.From("Test App"),
+            ExecutableName = Maybe.From("TestApp"),
+            InfoPlist = Maybe.From(ByteSource.FromString("""
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.example.packagerplist</string></dict></plist>
+"""))
+        };
+
+        var result = await new DmgPackager().Pack(container, metadata);
+        result.IsSuccess.Should().BeTrue();
+
+        var output = Path.Combine(tempRoot.Path, "TestApp.dmg");
+        var write = await result.Value.WriteTo(output);
+
+        write.IsSuccess.Should().BeTrue();
+        var data = await ExtractVolumeBytes(output);
+        Encoding.UTF8.GetString(data).Should().Contain("com.example.packagerplist");
+    }
+
+    [Fact]
+    public async Task Pack_should_map_metadata_to_generated_info_plist()
+    {
+        using var tempRoot = new TempDir();
+        var container = CreateContainer(ByteSource.FromBytes("exe"u8.ToArray()));
+        var metadata = new DmgPackagerMetadata
+        {
+            VolumeName = Maybe.From("Test App"),
+            ExecutableName = Maybe.From("TestApp"),
+            BundleIdentifier = Maybe.From("com.example.packagermetadata"),
+            BundleVersion = Maybe.From("3.2.1")
+        };
+
+        var result = await new DmgPackager().Pack(container, metadata);
+        result.IsSuccess.Should().BeTrue();
+
+        var output = Path.Combine(tempRoot.Path, "TestApp.dmg");
+        var write = await result.Value.WriteTo(output);
+
+        write.IsSuccess.Should().BeTrue();
+        var text = Encoding.UTF8.GetString(await ExtractVolumeBytes(output));
+        text.Should().Contain("com.example.packagermetadata");
+        text.Should().Contain("3.2.1");
+    }
+
     private static IContainer CreateContainer(IByteSource source)
     {
         return new RootContainer(
@@ -64,5 +117,11 @@ public class DmgPackagerTests
         return Directory
             .EnumerateFiles(Path.GetTempPath(), "dp-dmg-*.dmg")
             .Where(path => !existing.Contains(path));
+    }
+
+    private static async Task<byte[]> ExtractVolumeBytes(string dmgPath)
+    {
+        var udif = await UdifImage.Load(dmgPath);
+        return await udif.ExtractDataFork();
     }
 }

--- a/test/DotnetPackaging.E2E.Tests/PackagingTests.cs
+++ b/test/DotnetPackaging.E2E.Tests/PackagingTests.cs
@@ -106,6 +106,47 @@ public class PackagingTests : IDisposable
         File.Exists(output).Should().BeTrue();
     }
 
+    [Fact]
+    public async Task Can_create_Dmg_with_info_plist()
+    {
+        var plistPath = Path.Combine(temp.Path, "Info.plist");
+        File.WriteAllText(plistPath, """
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>com.example.e2eplist</string></dict></plist>
+""");
+
+        var output = Path.Combine(temp.Path, "TestAppWithInfoPlist.dmg");
+        await ExecutePackagingCommand("dmg", output, $"--arch x64 --info-plist \"{plistPath}\"");
+
+        File.Exists(output).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dmg_from_project_command_should_accept_info_plist()
+    {
+        var plistPath = Path.Combine(temp.Path, "Info.plist");
+        File.WriteAllText(plistPath, """
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict /></plist>
+""");
+
+        var command = DmgCommand.GetCommand();
+        var args = new[]
+        {
+            "from-project",
+            "--project", projectPath,
+            "--output", Path.Combine(temp.Path, "TestApp.dmg"),
+            "--arch", "x64",
+            "--appId", "com.example.cli",
+            "--version", "2.0.0",
+            "--info-plist", plistPath
+        };
+
+        var parseResult = command.Parse(args);
+        parseResult.Errors.Should().BeEmpty();
+        parseResult.UnmatchedTokens.Should().BeEmpty();
+    }
+
     private async Task ExecutePackagingCommand(string format, string outputPath, string extraArgs)
     {
         var toolProject = Path.Combine(repoRoot, "src", "DotnetPackaging.Tool", "DotnetPackaging.Tool.csproj");


### PR DESCRIPTION
## Summary
- Adds `--info-plist` support to DMG from-directory and from-project flows.
- Embeds custom or source-root `Info.plist` when generating an `.app` bundle, while preserving generated plist fallback.
- Maps existing project/CLI metadata (`PackageId`/`--appId`, `Version`/`--version`) into generated DMG plist metadata.
- Documents precedence: explicit CLI plist, source/project root plist, generated metadata.

Closes #162

## Validation
- `dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj --no-restore --filter "FullyQualifiedName~DmgHfsBuilderTests|FullyQualifiedName~DmgPackagerTests"`
- `dotnet test test/DotnetPackaging.E2E.Tests/DotnetPackaging.E2E.Tests.csproj --filter "FullyQualifiedName~Can_create_Dmg_with_info_plist|FullyQualifiedName~Dmg_from_project_command_should_accept_info_plist" --logger "console;verbosity=normal"`
- `dotnet test test/DotnetPackaging.Deb.Tests/DotnetPackaging.Deb.Tests.csproj --filter ProjectPackagingContextTests`
- `dotnet restore DotnetPackaging.sln && dotnet build DotnetPackaging.sln --no-restore`