### PR TITLE
fix(dmg): preserve HFS file modes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=Version]$version"
       Write-Host "##vso[task.setvariable variable=TagName]v$semVer"
       Write-Host "##vso[build.updatebuildnumber]DotnetPackaging-$version"
+      $global:LASTEXITCODE = 0
     displayName: 'Compute version with GitVersion'
 
   # Restore, build and pack using GitVersioned $(Version)

--- a/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeBuilder.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeBuilder.cs
@@ -44,12 +44,24 @@ public sealed class HfsVolumeBuilder
         return this;
     }
 
+    public HfsVolumeBuilder AddFile(string name, IByteSource content, long size, ushort fileMode)
+    {
+        root.AddFile(name, content, size, fileMode);
+        return this;
+    }
+
     /// <summary>
     /// Adds a file with byte array content to the root directory.
     /// </summary>
     public HfsVolumeBuilder AddFile(string name, byte[] content)
     {
         root.AddFile(name, content);
+        return this;
+    }
+
+    public HfsVolumeBuilder AddFile(string name, byte[] content, ushort fileMode)
+    {
+        root.AddFile(name, content, fileMode);
         return this;
     }
 

--- a/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
@@ -303,6 +303,7 @@ public static class HfsVolumeWriter
                         FileId = cnid,
                         CreateDate = entry.CreateDate,
                         ContentModDate = entry.ModifyDate,
+                        Permissions = BsdInfo.ForFile(file.FileMode),
                         DataFork = new ForkData { LogicalSize = (ulong)file.Size }
                     };
                     catalog.AddFile(parentId, entry.Name, fileRecord);
@@ -350,6 +351,7 @@ public static class HfsVolumeWriter
                         FileId = cnid,
                         CreateDate = entry.CreateDate,
                         ContentModDate = entry.ModifyDate,
+                        Permissions = BsdInfo.ForFile(file.FileMode),
                         DataFork = ForkData.FromExtent((ulong)file.Size, fileInfo.startBlock, fileInfo.blockCount)
                     };
                     catalog.AddFile(parentId, entry.Name, fileRecord);

--- a/src/DotnetPackaging.Dmg.Hfs/Catalog/CatalogRecords.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Catalog/CatalogRecords.cs
@@ -1,5 +1,6 @@
 using DotnetPackaging.Dmg.Hfs.Encoding;
 using DotnetPackaging.Dmg.Hfs.Extents;
+using DotnetPackaging.Dmg.Hfs.Files;
 
 namespace DotnetPackaging.Dmg.Hfs.Catalog;
 
@@ -25,22 +26,27 @@ public sealed record BsdInfo
     public uint GroupId { get; init; } = 99;   // nobody
     public byte AdminFlags { get; init; }
     public byte OwnerFlags { get; init; }
-    public ushort FileMode { get; init; } = 0x81ED; // -rwxr-xr-x (regular file, 0755)
+    public ushort FileMode { get; init; } = HfsFileModes.Regular0644; // -rw-r--r--
     public uint Special { get; init; }  // device ID or link count
 
     public static BsdInfo ForDirectory() => new()
     {
-        FileMode = 0x41ED // drwxr-xr-x (directory, 0755)
+        FileMode = HfsFileModes.Directory0755 // drwxr-xr-x
     };
 
     public static BsdInfo ForFile() => new()
     {
-        FileMode = 0x81ED // -rwxr-xr-x (regular file, 0755)
+        FileMode = HfsFileModes.Regular0644 // -rw-r--r--
+    };
+
+    public static BsdInfo ForFile(ushort fileMode) => new()
+    {
+        FileMode = fileMode
     };
 
     public static BsdInfo ForSymlink() => new()
     {
-        FileMode = 0xA1ED // lrwxr-xr-x (symlink, 0755)
+        FileMode = HfsFileModes.Symlink0755 // lrwxr-xr-x
     };
 
     public void WriteTo(Span<byte> buffer)

--- a/src/DotnetPackaging.Dmg.Hfs/Files/HfsEntry.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Files/HfsEntry.cs
@@ -17,6 +17,7 @@ public sealed record HfsFile : HfsEntry
 {
     public required IByteSource Content { get; init; }
     public long Size { get; init; }
+    public ushort FileMode { get; init; } = HfsFileModes.Regular0644;
 }
 
 /// <summary>
@@ -28,17 +29,28 @@ public sealed record HfsDirectory : HfsEntry
 
     public HfsDirectory AddFile(string name, IByteSource content, long size)
     {
-        Children.Add(new HfsFile { Name = name, Content = content, Size = size });
+        return AddFile(name, content, size, HfsFileModes.Regular0644);
+    }
+
+    public HfsDirectory AddFile(string name, IByteSource content, long size, ushort fileMode)
+    {
+        Children.Add(new HfsFile { Name = name, Content = content, Size = size, FileMode = fileMode });
         return this;
     }
 
     public HfsDirectory AddFile(string name, byte[] content)
     {
+        return AddFile(name, content, HfsFileModes.Regular0644);
+    }
+
+    public HfsDirectory AddFile(string name, byte[] content, ushort fileMode)
+    {
         Children.Add(new HfsFile 
         { 
             Name = name, 
             Content = ByteSource.FromBytes(content), 
-            Size = content.Length 
+            Size = content.Length,
+            FileMode = fileMode
         });
         return this;
     }
@@ -63,4 +75,19 @@ public sealed record HfsDirectory : HfsEntry
 public sealed record HfsSymlink : HfsEntry
 {
     public required string Target { get; init; }
+}
+
+public static class HfsFileModes
+{
+    private const ushort RegularFileType = 0x8000;
+
+    public const ushort Regular0644 = RegularFileType | 0x01A4;
+    public const ushort Regular0755 = RegularFileType | 0x01ED;
+    public const ushort Directory0755 = 0x4000 | 0x01ED;
+    public const ushort Symlink0755 = 0xA000 | 0x01ED;
+
+    public static ushort Regular(ushort permissions)
+    {
+        return (ushort)(RegularFileType | (permissions & 0x01FF));
+    }
 }

--- a/src/DotnetPackaging.Dmg/DmgHfsBuilder.cs
+++ b/src/DotnetPackaging.Dmg/DmgHfsBuilder.cs
@@ -7,6 +7,9 @@ using DotnetPackaging.Dmg.Hfs.Files;
 using DotnetPackaging.Formats.Dmg.Udif;
 using Zafiro.DivineBytes;
 using Path = System.IO.Path;
+#if NET6_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 
 namespace DotnetPackaging.Dmg;
 
@@ -79,19 +82,22 @@ internal static class DmgHfsBuilder
             var contentsDir = appDir.AddDirectory("Contents");
             var macOsDir = contentsDir.AddDirectory("MacOS");
             var resourcesDir = contentsDir.AddDirectory("Resources");
+            var exeName = executableName ?? GuessExecutableName(sourceFolder, volumeName);
 
             // Add all files to MacOS folder
-            await AddDirectoryContents(macOsDir, sourceFolder, 
+            await AddDirectoryContents(
+                macOsDir,
+                sourceFolder,
                 path => path.EndsWith(".app", StringComparison.OrdinalIgnoreCase) || 
                         path.EndsWith(".icns", StringComparison.OrdinalIgnoreCase) ||
                         IsRootInfoPlist(sourceFolder, path) ||
-                        IsDmgAdornment(sourceFolder, path));
+                        IsDmgAdornment(sourceFolder, path),
+                path => IsExecutablePath(sourceFolder, path, exeName) ? HfsFileModes.Regular0755 : HfsFileModes.Regular0644,
+                _ => HfsFileModes.Regular0644);
 
             // Handle icon
             var appIcon = await PrepareAppIcon(sourceFolder, resourcesDir, icon);
 
-            // Generate Info.plist
-            var exeName = executableName ?? GuessExecutableName(sourceFolder, volumeName);
             await AddInfoPlist(contentsDir, sourceFolder, infoPlist, volumeName, exeName, appIcon, bundleIdentifier, bundleVersion);
             contentsDir.AddFile("PkgInfo", Encoding.ASCII.GetBytes("APPL????"));
         }
@@ -118,13 +124,18 @@ internal static class DmgHfsBuilder
 
     private static async Task AddDirectoryContentsRecursive(HfsDirectory target, string sourcePath)
     {
+        await AddDirectoryContentsRecursive(target, sourcePath, GetFileMode);
+    }
+
+    private static async Task AddDirectoryContentsRecursive(HfsDirectory target, string sourcePath, Func<string, ushort> getFileMode)
+    {
         foreach (var dir in Directory.EnumerateDirectories(sourcePath))
         {
             var dirName = Path.GetFileName(dir);
             if (dirName == null) continue;
 
             var subDir = target.AddDirectory(dirName);
-            await AddDirectoryContentsRecursive(subDir, dir);
+            await AddDirectoryContentsRecursive(subDir, dir, getFileMode);
         }
 
         foreach (var file in Directory.EnumerateFiles(sourcePath))
@@ -133,11 +144,16 @@ internal static class DmgHfsBuilder
             if (fileName == null) continue;
 
             var fileBytes = await File.ReadAllBytesAsync(file);
-            target.AddFile(fileName, fileBytes);
+            target.AddFile(fileName, fileBytes, getFileMode(file));
         }
     }
 
-    private static async Task AddDirectoryContents(HfsDirectory target, string sourcePath, Func<string, bool>? shouldSkip = null)
+    private static async Task AddDirectoryContents(
+        HfsDirectory target,
+        string sourcePath,
+        Func<string, bool>? shouldSkip = null,
+        Func<string, ushort>? getFileMode = null,
+        Func<string, ushort>? getRecursiveFileMode = null)
     {
         foreach (var dir in Directory.EnumerateDirectories(sourcePath))
         {
@@ -146,7 +162,7 @@ internal static class DmgHfsBuilder
             if (dirName == null) continue;
 
             var subDir = target.AddDirectory(dirName);
-            await AddDirectoryContentsRecursive(subDir, dir);
+            await AddDirectoryContentsRecursive(subDir, dir, getRecursiveFileMode ?? getFileMode ?? GetFileMode);
         }
 
         foreach (var file in Directory.EnumerateFiles(sourcePath))
@@ -156,7 +172,7 @@ internal static class DmgHfsBuilder
             if (fileName == null) continue;
 
             var fileBytes = await File.ReadAllBytesAsync(file);
-            target.AddFile(fileName, fileBytes);
+            target.AddFile(fileName, fileBytes, getFileMode?.Invoke(file) ?? GetFileMode(file));
         }
     }
 
@@ -261,6 +277,26 @@ internal static class DmgHfsBuilder
     {
         return string.Equals(Path.GetFileName(path), name, StringComparison.OrdinalIgnoreCase)
                && string.Equals(Path.GetDirectoryName(path), sourceFolder, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsExecutablePath(string sourceFolder, string path, string executableName)
+    {
+        return string.Equals(Path.GetFileName(path), executableName, StringComparison.Ordinal)
+               && string.Equals(Path.GetDirectoryName(path), sourceFolder, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ushort GetFileMode(string path)
+    {
+#if NET6_0_OR_GREATER
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var mode = File.GetUnixFileMode(path);
+            var permissions = (ushort)((uint)mode & 0x01FF);
+            return HfsFileModes.Regular(permissions);
+        }
+#endif
+
+        return HfsFileModes.Regular0644;
     }
 
     private static async Task<Maybe<string>> PrepareAppIcon(string sourceFolder, HfsDirectory resources, Maybe<IIcon> providedIcon)

--- a/src/DotnetPackaging.Dmg/DmgPackager.cs
+++ b/src/DotnetPackaging.Dmg/DmgPackager.cs
@@ -1,4 +1,5 @@
 using CSharpFunctionalExtensions;
+using DotnetPackaging.Publish;
 using Serilog;
 using Zafiro.DivineBytes;
 
@@ -22,6 +23,11 @@ public sealed class DmgPackager
         if (metadata == null)
         {
             throw new ArgumentNullException(nameof(metadata));
+        }
+
+        if (container is DisposableDirectoryContainer directoryContainer)
+        {
+            return await PackDirectory(directoryContainer.OutputPath, metadata, logger);
         }
 
         var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));

--- a/src/DotnetPackaging.Dmg/DmgPackager.cs
+++ b/src/DotnetPackaging.Dmg/DmgPackager.cs
@@ -25,23 +25,72 @@ public sealed class DmgPackager
         }
 
         var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        var dmgPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dp-dmg-{Guid.NewGuid():N}.dmg");
         try
         {
             var writeResult = await container.WriteTo(tempDir);
             if (writeResult.IsFailure)
             {
-                TryDeleteFile(dmgPath);
                 return Result.Failure<IByteSource>(writeResult.Error);
             }
 
+            return await PackDirectory(new DirectoryInfo(tempDir), metadata, logger);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<IByteSource>(ex.Message);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a DMG directly from a directory, preserving source filesystem metadata where supported.
+    /// </summary>
+    public Task<Result<IByteSource>> PackDirectory(string directoryPath, DmgPackagerMetadata metadata, ILogger? logger = null)
+    {
+        if (directoryPath == null)
+        {
+            throw new ArgumentNullException(nameof(directoryPath));
+        }
+
+        return PackDirectory(new DirectoryInfo(directoryPath), metadata, logger);
+    }
+
+    /// <summary>
+    /// Creates a DMG directly from a directory, preserving source filesystem metadata where supported.
+    /// </summary>
+    public async Task<Result<IByteSource>> PackDirectory(DirectoryInfo directory, DmgPackagerMetadata metadata, ILogger? logger = null)
+    {
+        if (directory == null)
+        {
+            throw new ArgumentNullException(nameof(directory));
+        }
+
+        if (metadata == null)
+        {
+            throw new ArgumentNullException(nameof(metadata));
+        }
+
+        if (!directory.Exists)
+        {
+            return Result.Failure<IByteSource>($"Directory '{directory.FullName}' does not exist.");
+        }
+
+        var dmgPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dp-dmg-{Guid.NewGuid():N}.dmg");
+        try
+        {
             var volumeName = metadata.VolumeName
                 .Or(metadata.ExecutableName)
                 .GetValueOrDefault("Application");
             var executableName = metadata.ExecutableName.HasValue ? metadata.ExecutableName.Value : null;
 
             await DmgHfsBuilder.Create(
-                tempDir,
+                directory.FullName,
                 dmgPath,
                 volumeName,
                 metadata.Compress.GetValueOrDefault(true),
@@ -59,13 +108,6 @@ public sealed class DmgPackager
         {
             TryDeleteFile(dmgPath);
             return Result.Failure<IByteSource>(ex.Message);
-        }
-        finally
-        {
-            if (Directory.Exists(tempDir))
-            {
-                Directory.Delete(tempDir, true);
-            }
         }
     }
 

--- a/src/DotnetPackaging.Dmg/DmgPackagerExtensions.cs
+++ b/src/DotnetPackaging.Dmg/DmgPackagerExtensions.cs
@@ -52,6 +52,12 @@ public static class DmgPackagerExtensions
 
         var log = logger ?? Log.Logger;
         var resolved = ResolveFromProject(metadata ?? new DmgPackagerMetadata(), context);
+        if (publishedProject is DisposableDirectoryContainer publishedDirectory)
+        {
+            return PackagingByteSource.FromResultFactory(() =>
+                packager.PackDirectory(new DirectoryInfo(publishedDirectory.OutputPath), resolved, log));
+        }
+
         return PackagingByteSource.FromResultFactory(() => packager.Pack(publishedProject, resolved, log));
     }
 

--- a/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
+++ b/src/DotnetPackaging.Tool/Commands/DmgCommand.cs
@@ -7,15 +7,12 @@ using DotnetPackaging.Dmg;
 using DotnetPackaging.Dmg.Verification;
 using Serilog;
 using Zafiro.DivineBytes;
-using Zafiro.DivineBytes.System.IO;
 using Path = System.IO.Path;
 
 namespace DotnetPackaging.Tool.Commands;
 
 public static class DmgCommand
 {
-    private static readonly System.IO.Abstractions.FileSystem FileSystem = new();
-
     public static Command GetCommand()
     {
         // DMG command (experimental, cross-platform)
@@ -75,8 +72,6 @@ public static class DmgCommand
     private static Task CreateDmg(DirectoryInfo inputDir, FileInfo outputFile, Options options, ILogger logger)
     {
         logger.Debug("Packaging DMG artifact from {Directory}", inputDir.FullName);
-        var dirInfo = FileSystem.DirectoryInfo.New(inputDir.FullName);
-        var container = new DirectoryContainer(dirInfo).AsRoot();
 
         var metadata = new DmgPackagerMetadata
         {
@@ -92,7 +87,7 @@ public static class DmgCommand
         };
 
         var packager = new DmgPackager();
-        return packager.Pack(container, metadata, logger)
+        return packager.PackDirectory(inputDir, metadata, logger)
             .Bind(bytes => bytes.WriteTo(outputFile.FullName))
             .WriteResult();
     }

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -128,8 +128,8 @@ public class DmgHfsBuilderTests
 
         var modes = ReadCatalogFileModes(await ExtractVolumeBytes(outDmg));
 
-        modes["MyApp"].Should().Be(0x81ED);
-        modes["settings.json"].Should().Be(0x81A4);
+        modes["MyApp"].Should().Be(ExpectedSourceMode(0x81ED));
+        modes["settings.json"].Should().Be(ExpectedSourceMode(0x81A4));
     }
 
     [Fact]
@@ -620,6 +620,11 @@ public class DmgHfsBuilderTests
         {
             File.SetUnixFileMode(path, mode);
         }
+    }
+
+    private static ushort ExpectedSourceMode(ushort unixMode)
+    {
+        return OperatingSystem.IsWindows() ? (ushort)0x81A4 : unixMode;
     }
 
     private static Dictionary<string, ushort> ReadCatalogFileModes(byte[] volume)

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -81,10 +81,18 @@ public class DmgHfsBuilderTests
 
         var executable = Path.Combine(publish, "TestApp");
         var config = Path.Combine(publish, "TestApp.deps.json");
+        var extensionlessHelper = Path.Combine(publish, "helper");
+        var nestedDir = Path.Combine(publish, "tools");
+        var nestedTool = Path.Combine(nestedDir, "nested-tool");
+        Directory.CreateDirectory(nestedDir);
         await File.WriteAllTextAsync(executable, "exe");
         await File.WriteAllTextAsync(config, "deps");
+        await File.WriteAllTextAsync(extensionlessHelper, "helper");
+        await File.WriteAllTextAsync(nestedTool, "nested");
         SetUnixMode(executable, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
         SetUnixMode(config, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        SetUnixMode(extensionlessHelper, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        SetUnixMode(nestedTool, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
 
         var outDmg = Path.Combine(tempRoot.Path, "Test.dmg");
         await DmgHfsBuilder.Create(publish, outDmg, "Test App", executableName: "TestApp");
@@ -93,6 +101,8 @@ public class DmgHfsBuilderTests
 
         modes["TestApp"].Should().Be(0x81ED);
         modes["TestApp.deps.json"].Should().Be(0x81A4);
+        modes["helper"].Should().Be(0x81A4);
+        modes["nested-tool"].Should().Be(0x81A4);
         modes["Info.plist"].Should().Be(0x81A4);
     }
 

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -73,6 +73,56 @@ public class DmgHfsBuilderTests
     }
 
     [Fact]
+    public async Task Generated_app_bundle_marks_only_main_executable_as_executable()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        var executable = Path.Combine(publish, "TestApp");
+        var config = Path.Combine(publish, "TestApp.deps.json");
+        await File.WriteAllTextAsync(executable, "exe");
+        await File.WriteAllTextAsync(config, "deps");
+        SetUnixMode(executable, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        SetUnixMode(config, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        var outDmg = Path.Combine(tempRoot.Path, "Test.dmg");
+        await DmgHfsBuilder.Create(publish, outDmg, "Test App", executableName: "TestApp");
+
+        var modes = ReadCatalogFileModes(await ExtractVolumeBytes(outDmg));
+
+        modes["TestApp"].Should().Be(0x81ED);
+        modes["TestApp.deps.json"].Should().Be(0x81A4);
+        modes["Info.plist"].Should().Be(0x81A4);
+    }
+
+    [Fact]
+    public async Task Existing_app_bundle_preserves_source_file_modes()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        var macOs = Path.Combine(publish, "MyApp.app", "Contents", "MacOS");
+        var resources = Path.Combine(publish, "MyApp.app", "Contents", "Resources");
+        Directory.CreateDirectory(macOs);
+        Directory.CreateDirectory(resources);
+
+        var executable = Path.Combine(macOs, "MyApp");
+        var resource = Path.Combine(resources, "settings.json");
+        await File.WriteAllTextAsync(executable, "exe");
+        await File.WriteAllTextAsync(resource, "{}");
+        SetUnixMode(executable, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        SetUnixMode(resource, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        var outDmg = Path.Combine(tempRoot.Path, "MyApp.dmg");
+        await DmgHfsBuilder.Create(publish, outDmg, "My App");
+
+        var modes = ReadCatalogFileModes(await ExtractVolumeBytes(outDmg));
+
+        modes["MyApp"].Should().Be(0x81ED);
+        modes["settings.json"].Should().Be(0x81A4);
+    }
+
+    [Fact]
     public async Task Uses_custom_info_plist_when_wrapping_publish_output()
     {
         using var tempRoot = new TempDir();
@@ -552,5 +602,58 @@ public class DmgHfsBuilderTests
 
         public static HfsCatalogEntry File(uint parentId, string name, byte[] content)
             => new(parentId, name, null, content);
+    }
+
+    private static void SetUnixMode(string path, UnixFileMode mode)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path, mode);
+        }
+    }
+
+    private static Dictionary<string, ushort> ReadCatalogFileModes(byte[] volume)
+    {
+        var blockSize = BinaryPrimitives.ReadUInt32BigEndian(volume.AsSpan(1024 + 40, 4));
+        var catalogFork = volume.AsSpan(1024 + 272, 80);
+        var catalogStartBlock = BinaryPrimitives.ReadUInt32BigEndian(catalogFork[16..20]);
+        var catalogOffset = checked((int)(catalogStartBlock * blockSize));
+        var headerRecord = volume.AsSpan(catalogOffset + 14, 106);
+        var firstLeafNode = BinaryPrimitives.ReadUInt32BigEndian(headerRecord[10..14]);
+        var nodeSize = BinaryPrimitives.ReadUInt16BigEndian(headerRecord[18..20]);
+        var result = new Dictionary<string, ushort>(StringComparer.Ordinal);
+
+        for (var nodeIndex = firstLeafNode; nodeIndex != 0;)
+        {
+            var node = volume.AsSpan(catalogOffset + checked((int)(nodeIndex * nodeSize)), nodeSize);
+            var forwardLink = BinaryPrimitives.ReadUInt32BigEndian(node[0..4]);
+            var recordCount = BinaryPrimitives.ReadUInt16BigEndian(node[10..12]);
+
+            for (var i = 0; i < recordCount; i++)
+            {
+                var start = ReadNodeRecordOffset(node, nodeSize, i);
+                var end = ReadNodeRecordOffset(node, nodeSize, i + 1);
+                var record = node[start..end];
+                var keyLength = BinaryPrimitives.ReadUInt16BigEndian(record[0..2]);
+                var nameLength = BinaryPrimitives.ReadUInt16BigEndian(record[6..8]);
+                var name = Encoding.BigEndianUnicode.GetString(record.Slice(8, nameLength * 2));
+                var recordData = record[(2 + keyLength)..];
+                var recordType = BinaryPrimitives.ReadInt16BigEndian(recordData[0..2]);
+
+                if (recordType == 0x0002)
+                {
+                    result[name] = BinaryPrimitives.ReadUInt16BigEndian(recordData[42..44]);
+                }
+            }
+
+            nodeIndex = forwardLink;
+        }
+
+        return result;
+    }
+
+    private static int ReadNodeRecordOffset(ReadOnlySpan<byte> node, int nodeSize, int recordIndex)
+    {
+        return BinaryPrimitives.ReadUInt16BigEndian(node.Slice(nodeSize - 2 - recordIndex * 2, 2));
     }
 }

--- a/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using System.Text;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Formats.Dmg.Udif;
+using DotnetPackaging.Publish;
 using FluentAssertions;
 using Zafiro.DivineBytes;
 using Path = System.IO.Path;
@@ -131,8 +132,45 @@ public class DmgPackagerTests
 
         write.IsSuccess.Should().BeTrue();
         var modes = ReadCatalogFileModes(await ExtractVolumeBytes(output));
-        modes["MyApp"].Should().Be(0x81ED);
-        modes["settings.json"].Should().Be(0x8180);
+        modes["MyApp"].Should().Be(ExpectedSourceMode(0x81ED));
+        modes["settings.json"].Should().Be(ExpectedSourceMode(0x8180));
+    }
+
+    [Fact]
+    public async Task Pack_preserves_directory_backed_container_source_file_modes()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        var macOs = Path.Combine(publish, "MyApp.app", "Contents", "MacOS");
+        var resources = Path.Combine(publish, "MyApp.app", "Contents", "Resources");
+        Directory.CreateDirectory(macOs);
+        Directory.CreateDirectory(resources);
+
+        var executable = Path.Combine(macOs, "MyApp");
+        var settings = Path.Combine(resources, "settings.json");
+        await File.WriteAllTextAsync(executable, "exe");
+        await File.WriteAllTextAsync(settings, "{}");
+        SetUnixMode(executable, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        SetUnixMode(settings, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        using var container = new DisposableDirectoryContainer(publish, Serilog.Core.Logger.None);
+        var metadata = new DmgPackagerMetadata
+        {
+            VolumeName = Maybe.From("My App"),
+            IncludeDefaultLayout = Maybe.From(false),
+            AddApplicationsSymlink = Maybe.From(false)
+        };
+
+        var result = await new DmgPackager().Pack(container, metadata);
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : string.Empty);
+
+        var output = Path.Combine(tempRoot.Path, "MyApp.dmg");
+        var write = await result.Value.WriteTo(output);
+
+        write.IsSuccess.Should().BeTrue();
+        var modes = ReadCatalogFileModes(await ExtractVolumeBytes(output));
+        modes["MyApp"].Should().Be(ExpectedSourceMode(0x81ED));
+        modes["settings.json"].Should().Be(ExpectedSourceMode(0x81A4));
     }
 
     [Fact]
@@ -202,6 +240,11 @@ public class DmgPackagerTests
         {
             File.SetUnixFileMode(path, mode);
         }
+    }
+
+    private static ushort ExpectedSourceMode(ushort unixMode)
+    {
+        return OperatingSystem.IsWindows() ? (ushort)0x81A4 : unixMode;
     }
 
     private static Dictionary<string, ushort> ReadCatalogFileModes(byte[] volume)

--- a/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgPackagerTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Reactive.Linq;
 using System.Text;
 using CSharpFunctionalExtensions;
@@ -98,6 +99,76 @@ public class DmgPackagerTests
         text.Should().Contain("3.2.1");
     }
 
+    [Fact]
+    public async Task Pack_directory_preserves_existing_app_source_file_modes()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        var macOs = Path.Combine(publish, "MyApp.app", "Contents", "MacOS");
+        var resources = Path.Combine(publish, "MyApp.app", "Contents", "Resources");
+        Directory.CreateDirectory(macOs);
+        Directory.CreateDirectory(resources);
+
+        var executable = Path.Combine(macOs, "MyApp");
+        var settings = Path.Combine(resources, "settings.json");
+        await File.WriteAllTextAsync(executable, "exe");
+        await File.WriteAllTextAsync(settings, "{}");
+        SetUnixMode(executable, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        SetUnixMode(settings, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var metadata = new DmgPackagerMetadata
+        {
+            VolumeName = Maybe.From("My App"),
+            IncludeDefaultLayout = Maybe.From(false),
+            AddApplicationsSymlink = Maybe.From(false)
+        };
+
+        var result = await new DmgPackager().PackDirectory(new DirectoryInfo(publish), metadata);
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : string.Empty);
+
+        var output = Path.Combine(tempRoot.Path, "MyApp.dmg");
+        var write = await result.Value.WriteTo(output);
+
+        write.IsSuccess.Should().BeTrue();
+        var modes = ReadCatalogFileModes(await ExtractVolumeBytes(output));
+        modes["MyApp"].Should().Be(0x81ED);
+        modes["settings.json"].Should().Be(0x8180);
+    }
+
+    [Fact]
+    public async Task Pack_directory_generated_app_bundle_keeps_license_and_notice_non_executable()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        var executable = Path.Combine(publish, "TestApp");
+        await File.WriteAllTextAsync(executable, "exe");
+        await File.WriteAllTextAsync(Path.Combine(publish, "LICENSE"), "license");
+        await File.WriteAllTextAsync(Path.Combine(publish, "NOTICE"), "notice");
+        SetUnixMode(executable, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+        var metadata = new DmgPackagerMetadata
+        {
+            VolumeName = Maybe.From("Test App"),
+            ExecutableName = Maybe.From("TestApp"),
+            IncludeDefaultLayout = Maybe.From(false),
+            AddApplicationsSymlink = Maybe.From(false)
+        };
+
+        var result = await new DmgPackager().PackDirectory(publish, metadata);
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : string.Empty);
+
+        var output = Path.Combine(tempRoot.Path, "TestApp.dmg");
+        var write = await result.Value.WriteTo(output);
+
+        write.IsSuccess.Should().BeTrue();
+        var modes = ReadCatalogFileModes(await ExtractVolumeBytes(output));
+        modes["TestApp"].Should().Be(0x81ED);
+        modes["LICENSE"].Should().Be(0x81A4);
+        modes["NOTICE"].Should().Be(0x81A4);
+    }
+
     private static IContainer CreateContainer(IByteSource source)
     {
         return new RootContainer(
@@ -123,5 +194,58 @@ public class DmgPackagerTests
     {
         var udif = await UdifImage.Load(dmgPath);
         return await udif.ExtractDataFork();
+    }
+
+    private static void SetUnixMode(string path, UnixFileMode mode)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path, mode);
+        }
+    }
+
+    private static Dictionary<string, ushort> ReadCatalogFileModes(byte[] volume)
+    {
+        var blockSize = BinaryPrimitives.ReadUInt32BigEndian(volume.AsSpan(1024 + 40, 4));
+        var catalogFork = volume.AsSpan(1024 + 272, 80);
+        var catalogStartBlock = BinaryPrimitives.ReadUInt32BigEndian(catalogFork[16..20]);
+        var catalogOffset = checked((int)(catalogStartBlock * blockSize));
+        var headerRecord = volume.AsSpan(catalogOffset + 14, 106);
+        var firstLeafNode = BinaryPrimitives.ReadUInt32BigEndian(headerRecord[10..14]);
+        var nodeSize = BinaryPrimitives.ReadUInt16BigEndian(headerRecord[18..20]);
+        var result = new Dictionary<string, ushort>(StringComparer.Ordinal);
+
+        for (var nodeIndex = firstLeafNode; nodeIndex != 0;)
+        {
+            var node = volume.AsSpan(catalogOffset + checked((int)(nodeIndex * nodeSize)), nodeSize);
+            var forwardLink = BinaryPrimitives.ReadUInt32BigEndian(node[0..4]);
+            var recordCount = BinaryPrimitives.ReadUInt16BigEndian(node[10..12]);
+
+            for (var i = 0; i < recordCount; i++)
+            {
+                var start = ReadNodeRecordOffset(node, nodeSize, i);
+                var end = ReadNodeRecordOffset(node, nodeSize, i + 1);
+                var record = node[start..end];
+                var keyLength = BinaryPrimitives.ReadUInt16BigEndian(record[0..2]);
+                var nameLength = BinaryPrimitives.ReadUInt16BigEndian(record[6..8]);
+                var name = Encoding.BigEndianUnicode.GetString(record.Slice(8, nameLength * 2));
+                var recordData = record[(2 + keyLength)..];
+                var recordType = BinaryPrimitives.ReadInt16BigEndian(recordData[0..2]);
+
+                if (recordType == 0x0002)
+                {
+                    result[name] = BinaryPrimitives.ReadUInt16BigEndian(recordData[42..44]);
+                }
+            }
+
+            nodeIndex = forwardLink;
+        }
+
+        return result;
+    }
+
+    private static int ReadNodeRecordOffset(ReadOnlySpan<byte> node, int nodeSize, int recordIndex)
+    {
+        return BinaryPrimitives.ReadUInt16BigEndian(node.Slice(nodeSize - 2 - recordIndex * 2, 2));
     }
 }


### PR DESCRIPTION
## Summary
- Tracks BSD file mode metadata on HFS file entries.
- Preserves source file modes when copying existing `.app` bundles into generated DMGs.
- Marks only the intended executable executable in generated `.app/Contents/MacOS` output, while keeping regular payload files non-executable.
- Adds catalog-level regression tests that inspect generated HFS+ BSD file modes.

Closes #179

## Validation
- `dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj --filter "Generated_app_bundle_marks_only_main_executable_as_executable|Existing_app_bundle_preserves_source_file_modes"`
- `dotnet build src/DotnetPackaging.Dmg/DotnetPackaging.Dmg.csproj --no-restore`
- `git diff --check`