### PR TITLE
test(dmg): update verifier success expectation

### DIFF
--- a/test/DotnetPackaging.Dmg.Tests/DmgVerifierTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgVerifierTests.cs
@@ -7,7 +7,7 @@ namespace DotnetPackaging.Dmg.Tests;
 public class DmgVerifierTests
 {
     [Fact]
-    public async Task Verify_udif_dmg_reports_structural_only_validation()
+    public async Task Verify_udif_dmg_reports_udif_file_count_validation()
     {
         using var tempRoot = new TempDir();
         var publish = Path.Combine(tempRoot.Path, "publish");
@@ -20,6 +20,7 @@ public class DmgVerifierTests
         var result = await DmgVerifier.Verify(outDmg);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Contain("structural-only");
+        result.Value.Should().Contain("UDIF DMG OK");
+        result.Value.Should().Contain("files=");
     }
 }


### PR DESCRIPTION
## Summary
- Updates the DMG verifier regression test to assert the HFS-aware UDIF success message introduced by #183.
- Keeps the assertion stable by checking `UDIF DMG OK` and `files=` instead of the exact full string.

Follow-up for #175 and PR #183 review.

## Validation
- `dotnet restore test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj`
- `dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj --no-restore --filter "FullyQualifiedName~Dmg_verify_accepts_matching_hfs_file_count|FullyQualifiedName~Dmg_verify_rejects_mismatched_hfs_file_count"`
- `dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj --no-restore -m:1`