### PR TITLE
fix: stream DMG HFS generation

### DIFF
--- a/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
@@ -29,8 +29,22 @@ public static class HfsVolumeWriter
     /// </summary>
     public static IByteSource Write(HfsVolume volume)
     {
-        var bytes = WriteToBytes(volume);
-        return ByteSource.FromBytes(bytes);
+        return ByteSourceMaterializationExtensions.FromTempFileFactory(async () =>
+        {
+            var file = MaterializedByteSourceFile.Create(".hfs");
+
+            try
+            {
+                await using var output = File.Open(file.Path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
+                await WriteToAsync(volume, output).ConfigureAwait(false);
+                return file;
+            }
+            catch (Exception ex)
+            {
+                file.Dispose();
+                return Result.Failure<MaterializedByteSourceFile>(ex.Message);
+            }
+        });
     }
 
     /// <summary>
@@ -41,11 +55,28 @@ public static class HfsVolumeWriter
     /// </summary>
     public static byte[] WriteToBytes(HfsVolume volume)
     {
+        using var stream = new MemoryStream();
+        WriteToAsync(volume, stream).GetAwaiter().GetResult();
+        return stream.ToArray();
+    }
+
+    public static async Task WriteToAsync(HfsVolume volume, Stream output, CancellationToken cancellationToken = default)
+    {
+        if (!output.CanSeek)
+        {
+            throw new ArgumentException("HFS+ volume output must be seekable.", nameof(output));
+        }
+
+        if (!output.CanWrite)
+        {
+            throw new ArgumentException("HFS+ volume output must be writable.", nameof(output));
+        }
+
         var blockSize = volume.BlockSize;
         var (fileCount, folderCount) = volume.CountEntries();
 
-        // Collect all files and their data
-        var fileDataList = new List<(HfsFile file, byte[] data, uint startBlock, uint blockCount)>();
+        // Collect file metadata without reading source bytes.
+        var fileDataList = new List<FileData>();
         var symlinkDataList = new List<(HfsSymlink symlink, byte[] data, uint startBlock, uint blockCount)>();
         
         CollectFileData(volume.Root, fileDataList, symlinkDataList);
@@ -74,7 +105,7 @@ public static class HfsVolumeWriter
         var attributesBlocks = 1u; // Minimum 1 block
         
         // Calculate data blocks
-        var dataBlocksNeeded = (uint)fileDataList.Sum(f => (f.data.Length + (long)blockSize - 1) / blockSize)
+        var dataBlocksNeeded = (uint)fileDataList.Sum(f => (f.Length + (long)blockSize - 1) / blockSize)
                              + (uint)symlinkDataList.Sum(s => (s.data.Length + (long)blockSize - 1) / blockSize);
 
         // 3. Iterate to find TotalBlocks (converge on AllocationFile size)
@@ -134,9 +165,9 @@ public static class HfsVolumeWriter
         // Allocate Files
         for (var i = 0; i < fileDataList.Count; i++)
         {
-            var (file, data, _, _) = fileDataList[i];
-            var blocks = (uint)((data.Length + blockSize - 1) / blockSize);
-            fileDataList[i] = (file, data, Allocate(blocks), blocks);
+            var fileData = fileDataList[i];
+            var blocks = (uint)((fileData.Length + blockSize - 1) / blockSize);
+            fileDataList[i] = fileData with { StartBlock = Allocate(blocks), BlockCount = blocks };
         }
 
         for (var i = 0; i < symlinkDataList.Count; i++)
@@ -170,47 +201,58 @@ public static class HfsVolumeWriter
             AttributesFile = ForkData.FromExtent(blockSize, attributesStartBlock, attributesBlocks) with { ClumpSize = blockSize }
         };
 
-        // 7. Write Result Buffer
-        // Total size is exactly TotalBlocks * BlockSize
+        // 7. Write Result Stream
+        // Total size is exactly TotalBlocks * BlockSize. Seekable streams keep unwritten padding zeroed.
         var totalSizeBytes = (long)totalBlocks * blockSize;
-        var buffer = new byte[totalSizeBytes];
+        output.SetLength(totalSizeBytes);
 
-        // Helper to write data at block offset
-        void WriteAtBlock(uint blockIdx, byte[] data)
+        async Task WriteAtBlock(uint blockIdx, byte[] data)
         {
             if (blockIdx == 0 && data.Length == 0) return;
-             // Determine exact byte offset
-            var offset = (long)blockIdx * blockSize;
-            data.CopyTo(buffer.AsSpan((int)offset)); // Assuming DMG < 2GB for array
+            output.Position = (long)blockIdx * blockSize;
+            await output.WriteAsync(data, cancellationToken).ConfigureAwait(false);
         }
         
         // Write Headers
         // Boot blocks are 0-1024 (Zeroed)
         // Volume header is 1024-1536
-        header.WriteTo(buffer.AsSpan(VolumeHeaderOffset, VolumeHeader.Size));
+        var volumeHeaderBytes = new byte[VolumeHeader.Size];
+        header.WriteTo(volumeHeaderBytes);
+        output.Position = VolumeHeaderOffset;
+        await output.WriteAsync(volumeHeaderBytes, cancellationToken).ConfigureAwait(false);
 
         // Write Metadata
-        WriteAtBlock(allocationStartBlock, allocation.ToBytes());
-        WriteAtBlock(extentsStartBlock, extents.ToBytes()); // if size > 0
-        WriteAtBlock(catalogStartBlock, catalog.ToBytes());
-        WriteAtBlock(attributesStartBlock, attributes.ToBytes());
+        await WriteAtBlock(allocationStartBlock, allocation.ToBytes()).ConfigureAwait(false);
+        await WriteAtBlock(extentsStartBlock, extents.ToBytes()).ConfigureAwait(false);
+        await WriteAtBlock(catalogStartBlock, catalog.ToBytes()).ConfigureAwait(false);
+        await WriteAtBlock(attributesStartBlock, attributes.ToBytes()).ConfigureAwait(false);
         
         // Write Files
-        foreach (var (_, data, start, _) in fileDataList) WriteAtBlock(start, data);
-        foreach (var (_, data, start, _) in symlinkDataList) WriteAtBlock(start, data);
+        foreach (var fileData in fileDataList)
+        {
+            output.Position = (long)fileData.StartBlock * blockSize;
+            var write = await fileData.File.Content.WriteTo(output, cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (write.IsFailure)
+            {
+                throw new InvalidOperationException($"Could not write HFS+ file '{fileData.File.Name}': {write.Error}");
+            }
+        }
+
+        foreach (var (_, data, start, _) in symlinkDataList)
+        {
+            await WriteAtBlock(start, data).ConfigureAwait(false);
+        }
 
         // Write Alt Header
         // Located in second-to-last 512-byte sector.
         // Offset = TotalSizeBytes - 1024
-        var altHeaderOffset = (int)(totalSizeBytes - 1024);
-        header.WriteTo(buffer.AsSpan(altHeaderOffset, VolumeHeader.Size));
-
-        return buffer;
+        output.Position = totalSizeBytes - 1024;
+        await output.WriteAsync(volumeHeaderBytes, cancellationToken).ConfigureAwait(false);
     }
 
     private static void CollectFileData(
         HfsDirectory dir,
-        List<(HfsFile file, byte[] data, uint startBlock, uint blockCount)> fileDataList,
+        List<FileData> fileDataList,
         List<(HfsSymlink symlink, byte[] data, uint startBlock, uint blockCount)> symlinkDataList)
     {
         foreach (var entry in dir.Children)
@@ -218,8 +260,7 @@ public static class HfsVolumeWriter
             switch (entry)
             {
                 case HfsFile file:
-                    var fileData = file.Content.ToStream().ReadAllBytes();
-                    fileDataList.Add((file, fileData, 0, 0));
+                    fileDataList.Add(new FileData(file, file.Size, 0, 0));
                     break;
                 case HfsSymlink symlink:
                     var linkData = System.Text.Encoding.UTF8.GetBytes(symlink.Target);
@@ -234,7 +275,7 @@ public static class HfsVolumeWriter
 
     private static CatalogBTree BuildCatalog(
         HfsVolume volume,
-        List<(HfsFile file, byte[] data, uint startBlock, uint blockCount)> fileDataList,
+        List<FileData> fileDataList,
         List<(HfsSymlink symlink, byte[] data, uint startBlock, uint blockCount)> symlinkDataList,
         out uint nextCnid)
     {
@@ -253,7 +294,7 @@ public static class HfsVolumeWriter
 
     private static CatalogBTree BuildCatalogWithBlocks(
         HfsVolume volume,
-        List<(HfsFile file, byte[] data, uint startBlock, uint blockCount)> fileDataList,
+        List<FileData> fileDataList,
         List<(HfsSymlink symlink, byte[] data, uint startBlock, uint blockCount)> symlinkDataList,
         out uint nextCnid)
     {
@@ -274,7 +315,7 @@ public static class HfsVolumeWriter
         CatalogBTree catalog,
         CatalogNodeId parentId,
         HfsDirectory dir,
-        List<(HfsFile file, byte[] data, uint startBlock, uint blockCount)> fileDataList,
+        List<FileData> fileDataList,
         List<(HfsSymlink symlink, byte[] data, uint startBlock, uint blockCount)> symlinkDataList,
         ref uint nextCnid,
         uint blockSize)
@@ -321,7 +362,7 @@ public static class HfsVolumeWriter
         CatalogBTree catalog,
         CatalogNodeId parentId,
         HfsDirectory dir,
-        List<(HfsFile file, byte[] data, uint startBlock, uint blockCount)> fileDataList,
+        List<FileData> fileDataList,
         List<(HfsSymlink symlink, byte[] data, uint startBlock, uint blockCount)> symlinkDataList,
         ref uint nextCnid,
         uint blockSize)
@@ -345,14 +386,14 @@ public static class HfsVolumeWriter
                     break;
 
                 case HfsFile file:
-                    var fileInfo = fileDataList.FirstOrDefault(f => f.file == file);
+                    var fileInfo = fileDataList.First(f => f.File == file);
                     var fileRecord = new CatalogFileRecord
                     {
                         FileId = cnid,
                         CreateDate = entry.CreateDate,
                         ContentModDate = entry.ModifyDate,
                         Permissions = BsdInfo.ForFile(file.FileMode),
-                        DataFork = ForkData.FromExtent((ulong)file.Size, fileInfo.startBlock, fileInfo.blockCount)
+                        DataFork = ForkData.FromExtent((ulong)file.Size, fileInfo.StartBlock, fileInfo.BlockCount)
                     };
                     catalog.AddFile(parentId, entry.Name, fileRecord);
                     break;
@@ -375,20 +416,6 @@ public static class HfsVolumeWriter
             }
         }
     }
-}
 
-/// <summary>
-/// Extension methods for Stream.
-/// </summary>
-internal static class StreamExtensions
-{
-    public static byte[] ReadAllBytes(this Stream stream)
-    {
-        if (stream is MemoryStream ms)
-            return ms.ToArray();
-
-        using var memoryStream = new MemoryStream();
-        stream.CopyTo(memoryStream);
-        return memoryStream.ToArray();
-    }
+    private sealed record FileData(HfsFile File, long Length, uint StartBlock, uint BlockCount);
 }

--- a/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Builder/HfsVolumeWriter.cs
@@ -50,9 +50,6 @@ public static class HfsVolumeWriter
     /// <summary>
     /// Writes an HFS+ volume to a byte array.
     /// </summary>
-    /// <summary>
-    /// Writes an HFS+ volume to a byte array.
-    /// </summary>
     public static byte[] WriteToBytes(HfsVolume volume)
     {
         using var stream = new MemoryStream();
@@ -231,11 +228,7 @@ public static class HfsVolumeWriter
         foreach (var fileData in fileDataList)
         {
             output.Position = (long)fileData.StartBlock * blockSize;
-            var write = await fileData.File.Content.WriteTo(output, cancellationToken: cancellationToken).ConfigureAwait(false);
-            if (write.IsFailure)
-            {
-                throw new InvalidOperationException($"Could not write HFS+ file '{fileData.File.Name}': {write.Error}");
-            }
+            await WriteFileContent(fileData.File, output, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var (_, data, start, _) in symlinkDataList)
@@ -260,6 +253,11 @@ public static class HfsVolumeWriter
             switch (entry)
             {
                 case HfsFile file:
+                    if (file.Size < 0)
+                    {
+                        throw new InvalidOperationException($"HFS+ file '{file.Name}' cannot have a negative size ({file.Size}).");
+                    }
+
                     fileDataList.Add(new FileData(file, file.Size, 0, 0));
                     break;
                 case HfsSymlink symlink:
@@ -417,5 +415,86 @@ public static class HfsVolumeWriter
         }
     }
 
+    private static async Task WriteFileContent(HfsFile file, Stream output, CancellationToken cancellationToken)
+    {
+        var boundedOutput = new DeclaredLengthWriteStream(output, file.Name, file.Size);
+        var write = await file.Content.WriteTo(boundedOutput, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (write.IsFailure)
+        {
+            throw new InvalidOperationException($"Could not write HFS+ file '{file.Name}': {write.Error}");
+        }
+
+        if (boundedOutput.BytesWritten != file.Size)
+        {
+            throw new InvalidOperationException(
+                $"HFS+ file '{file.Name}' ended before its declared size. Declared size: {file.Size} bytes; emitted/written bytes: {boundedOutput.BytesWritten} bytes.");
+        }
+    }
+
     private sealed record FileData(HfsFile File, long Length, uint StartBlock, uint BlockCount);
+
+    private sealed class DeclaredLengthWriteStream(Stream inner, string fileName, long declaredSize) : Stream
+    {
+        public long BytesWritten { get; private set; }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return inner.FlushAsync(cancellationToken);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ValidateWriteCount(count);
+            inner.Write(buffer, offset, count);
+            BytesWritten += count;
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateWriteCount(count);
+            await inner.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            BytesWritten += count;
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            ValidateWriteCount(buffer.Length);
+            inner.Write(buffer);
+            BytesWritten += buffer.Length;
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ValidateWriteCount(buffer.Length);
+            await inner.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            BytesWritten += buffer.Length;
+        }
+
+        private void ValidateWriteCount(int count)
+        {
+            var emittedBytes = BytesWritten + count;
+            if (emittedBytes > declaredSize)
+            {
+                throw new InvalidOperationException(
+                    $"HFS+ file '{fileName}' exceeded its declared size before writing the overflowing chunk. Declared size: {declaredSize} bytes; emitted bytes: {emittedBytes} bytes; written bytes: {BytesWritten} bytes.");
+            }
+        }
+    }
 }

--- a/src/DotnetPackaging.Dmg.Hfs/Files/HfsEntry.cs
+++ b/src/DotnetPackaging.Dmg.Hfs/Files/HfsEntry.cs
@@ -34,6 +34,11 @@ public sealed record HfsDirectory : HfsEntry
 
     public HfsDirectory AddFile(string name, IByteSource content, long size, ushort fileMode)
     {
+        if (size < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(size), size, $"HFS+ file '{name}' cannot have a negative size.");
+        }
+
         Children.Add(new HfsFile { Name = name, Content = content, Size = size, FileMode = fileMode });
         return this;
     }

--- a/src/DotnetPackaging.Dmg/DmgHfsBuilder.cs
+++ b/src/DotnetPackaging.Dmg/DmgHfsBuilder.cs
@@ -51,6 +51,45 @@ internal static class DmgHfsBuilder
         Maybe<string> bundleIdentifier = default,
         Maybe<string> bundleVersion = default)
     {
+        var volume = await BuildVolume(
+            sourceFolder,
+            volumeName,
+            addApplicationsSymlink,
+            includeDefaultLayout,
+            icon,
+            executableName,
+            infoPlist,
+            bundleIdentifier,
+            bundleVersion).ConfigureAwait(false);
+
+        using var hfsFile = MaterializedByteSourceFile.Create(".hfs");
+        await using (var hfsOutput = File.Open(hfsFile.Path, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None))
+        {
+            await HfsVolumeWriter.WriteToAsync(volume, hfsOutput).ConfigureAwait(false);
+        }
+
+        await using var hfsStream = File.Open(hfsFile.Path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        await using var dmgStream = File.Open(outputPath, FileMode.Create, FileAccess.Write, FileShare.None);
+
+        var udifWriter = new UdifWriter
+        {
+            CompressionType = compress ? CompressionType.Zlib : CompressionType.Raw
+        };
+
+        udifWriter.Create(hfsStream, dmgStream);
+    }
+
+    internal static async Task<HfsVolume> BuildVolume(
+        string sourceFolder,
+        string volumeName,
+        bool addApplicationsSymlink = false,
+        bool includeDefaultLayout = true,
+        Maybe<IIcon> icon = default,
+        string? executableName = null,
+        Maybe<IByteSource> infoPlist = default,
+        Maybe<string> bundleIdentifier = default,
+        Maybe<string> bundleVersion = default)
+    {
         var builder = HfsVolumeBuilder.Create(SanitizeVolumeName(volumeName));
 
         // Add Applications symlink if requested
@@ -71,7 +110,7 @@ internal static class DmgHfsBuilder
                 if (bundleName == null) continue;
                 
                 var appDir = builder.AddDirectory(bundleName);
-                await AddDirectoryContentsRecursive(appDir, bundle);
+                AddDirectoryContentsRecursive(appDir, bundle);
             }
         }
         else
@@ -85,7 +124,7 @@ internal static class DmgHfsBuilder
             var exeName = executableName ?? GuessExecutableName(sourceFolder, volumeName);
 
             // Add all files to MacOS folder
-            await AddDirectoryContents(
+            AddDirectoryContents(
                 macOsDir,
                 sourceFolder,
                 path => path.EndsWith(".app", StringComparison.OrdinalIgnoreCase) || 
@@ -102,32 +141,17 @@ internal static class DmgHfsBuilder
             contentsDir.AddFile("PkgInfo", Encoding.ASCII.GetBytes("APPL????"));
         }
 
-        await AddDmgAdornments(builder, sourceFolder, includeDefaultLayout);
+        AddDmgAdornments(builder, sourceFolder, includeDefaultLayout);
 
-        // Build the HFS+ volume
-        var volume = builder.Build();
-        var hfsBytes = HfsVolumeWriter.WriteToBytes(volume);
-        
-        // Wrap HFS+ volume in UDIF format (DMG)
-        using var hfsStream = new MemoryStream(hfsBytes);
-        using var dmgStream = new MemoryStream();
-        
-        var udifWriter = new UdifWriter
-        {
-            CompressionType = compress ? CompressionType.Zlib : CompressionType.Raw
-        };
-        
-        udifWriter.Create(hfsStream, dmgStream);
-        
-        await File.WriteAllBytesAsync(outputPath, dmgStream.ToArray());
+        return builder.Build();
     }
 
-    private static async Task AddDirectoryContentsRecursive(HfsDirectory target, string sourcePath)
+    private static void AddDirectoryContentsRecursive(HfsDirectory target, string sourcePath)
     {
-        await AddDirectoryContentsRecursive(target, sourcePath, GetFileMode);
+        AddDirectoryContentsRecursive(target, sourcePath, GetFileMode);
     }
 
-    private static async Task AddDirectoryContentsRecursive(HfsDirectory target, string sourcePath, Func<string, ushort> getFileMode)
+    private static void AddDirectoryContentsRecursive(HfsDirectory target, string sourcePath, Func<string, ushort> getFileMode)
     {
         foreach (var dir in Directory.EnumerateDirectories(sourcePath))
         {
@@ -135,7 +159,7 @@ internal static class DmgHfsBuilder
             if (dirName == null) continue;
 
             var subDir = target.AddDirectory(dirName);
-            await AddDirectoryContentsRecursive(subDir, dir, getFileMode);
+            AddDirectoryContentsRecursive(subDir, dir, getFileMode);
         }
 
         foreach (var file in Directory.EnumerateFiles(sourcePath))
@@ -143,12 +167,11 @@ internal static class DmgHfsBuilder
             var fileName = Path.GetFileName(file);
             if (fileName == null) continue;
 
-            var fileBytes = await File.ReadAllBytesAsync(file);
-            target.AddFile(fileName, fileBytes, getFileMode(file));
+            AddFileFromPath(target, fileName, file, getFileMode(file));
         }
     }
 
-    private static async Task AddDirectoryContents(
+    private static void AddDirectoryContents(
         HfsDirectory target,
         string sourcePath,
         Func<string, bool>? shouldSkip = null,
@@ -162,7 +185,7 @@ internal static class DmgHfsBuilder
             if (dirName == null) continue;
 
             var subDir = target.AddDirectory(dirName);
-            await AddDirectoryContentsRecursive(subDir, dir, getRecursiveFileMode ?? getFileMode ?? GetFileMode);
+            AddDirectoryContentsRecursive(subDir, dir, getRecursiveFileMode ?? getFileMode ?? GetFileMode);
         }
 
         foreach (var file in Directory.EnumerateFiles(sourcePath))
@@ -171,8 +194,7 @@ internal static class DmgHfsBuilder
             var fileName = Path.GetFileName(file);
             if (fileName == null) continue;
 
-            var fileBytes = await File.ReadAllBytesAsync(file);
-            target.AddFile(fileName, fileBytes, getFileMode?.Invoke(file) ?? GetFileMode(file));
+            AddFileFromPath(target, fileName, file, getFileMode?.Invoke(file) ?? GetFileMode(file));
         }
     }
 
@@ -230,7 +252,7 @@ internal static class DmgHfsBuilder
         return IsRootEntry(sourceFolder, path, "Info.plist");
     }
 
-    private static async Task AddDmgAdornments(HfsVolumeBuilder builder, string sourceFolder, bool includeDefaultLayout)
+    private static void AddDmgAdornments(HfsVolumeBuilder builder, string sourceFolder, bool includeDefaultLayout)
     {
         var backgroundPath = Path.Combine(sourceFolder, BackgroundDirectoryName);
         var hasCustomBackground = Directory.Exists(backgroundPath);
@@ -239,7 +261,7 @@ internal static class DmgHfsBuilder
             var backgroundDir = builder.AddDirectory(BackgroundDirectoryName);
             if (hasCustomBackground)
             {
-                await AddDirectoryContentsRecursive(backgroundDir, backgroundPath);
+                AddDirectoryContentsRecursive(backgroundDir, backgroundPath);
             }
 
             var defaultBackgroundPath = Path.Combine(backgroundPath, DefaultBackgroundFileName);
@@ -252,7 +274,7 @@ internal static class DmgHfsBuilder
         var dsStorePath = Path.Combine(sourceFolder, DsStoreFileName);
         if (File.Exists(dsStorePath))
         {
-            builder.AddFile(DsStoreFileName, await File.ReadAllBytesAsync(dsStorePath));
+            AddFileFromPath(builder.Root, DsStoreFileName, dsStorePath);
         }
         else if (includeDefaultLayout)
         {
@@ -262,7 +284,7 @@ internal static class DmgHfsBuilder
         var volumeIconPath = Path.Combine(sourceFolder, VolumeIconFileName);
         if (File.Exists(volumeIconPath))
         {
-            builder.AddFile(VolumeIconFileName, await File.ReadAllBytesAsync(volumeIconPath));
+            AddFileFromPath(builder.Root, VolumeIconFileName, volumeIconPath);
         }
     }
 
@@ -299,6 +321,12 @@ internal static class DmgHfsBuilder
         return HfsFileModes.Regular0644;
     }
 
+    private static void AddFileFromPath(HfsDirectory target, string fileName, string path, ushort? fileMode = null)
+    {
+        var fileInfo = new FileInfo(path);
+        target.AddFile(fileName, FileByteSource.OpenRead(fileInfo), fileInfo.Length, fileMode ?? GetFileMode(path));
+    }
+
     private static async Task<Maybe<string>> PrepareAppIcon(string sourceFolder, HfsDirectory resources, Maybe<IIcon> providedIcon)
     {
         if (providedIcon.HasValue)
@@ -310,8 +338,7 @@ internal static class DmgHfsBuilder
         if (existingIcns != null)
         {
             var fileName = Path.GetFileName(existingIcns)!;
-            var iconBytes = await File.ReadAllBytesAsync(existingIcns);
-            resources.AddFile(fileName, iconBytes);
+            AddFileFromPath(resources, fileName, existingIcns);
             return Path.GetFileNameWithoutExtension(existingIcns);
         }
 

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using System.Text;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Dmg;
+using DotnetPackaging.Dmg.Hfs.Builder;
 using DotnetPackaging.Dmg.Hfs.Files;
 using DotnetPackaging.Dmg.Verification;
 using DotnetPackaging.Formats.Dmg.Udif;
@@ -490,6 +491,44 @@ public class DmgHfsBuilderTests
     }
 
     [Fact]
+    public async Task BuildVolume_ShouldRejectFileBackedSourceThatGrowsAfterVolumeIsBuilt()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        var payloadPath = Path.Combine(publish, "payload.bin");
+        await File.WriteAllBytesAsync(payloadPath, "tiny"u8.ToArray());
+
+        var volume = await DmgHfsBuilder.BuildVolume(publish, "Growing Payload", includeDefaultLayout: false);
+        await File.WriteAllBytesAsync(payloadPath, "this payload is longer"u8.ToArray());
+
+        var act = async () => await WriteVolumeToMemory(volume);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*payload.bin*exceeded its declared size*Declared size: 4 bytes*");
+    }
+
+    [Fact]
+    public async Task BuildVolume_ShouldRejectFileBackedSourceThatShrinksAfterVolumeIsBuilt()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        var payloadPath = Path.Combine(publish, "payload.bin");
+        await File.WriteAllBytesAsync(payloadPath, "this payload is longer"u8.ToArray());
+
+        var volume = await DmgHfsBuilder.BuildVolume(publish, "Shrinking Payload", includeDefaultLayout: false);
+        await File.WriteAllBytesAsync(payloadPath, "tiny"u8.ToArray());
+
+        var act = async () => await WriteVolumeToMemory(volume);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*payload.bin*ended before its declared size*Declared size: 22 bytes*emitted/written bytes: 4 bytes*");
+    }
+
+    [Fact]
     public async Task BuildVolume_ShouldPreserveCustomDmgAdornmentsAsLazyFileBackedByteSources()
     {
         using var tempRoot = new TempDir();
@@ -556,6 +595,12 @@ public class DmgHfsBuilderTests
         await using var output = File.Create(dmgPath);
         using var input = new MemoryStream(volume);
         new UdifWriter { CompressionType = CompressionType.Raw }.Create(input, output);
+    }
+
+    private static async Task WriteVolumeToMemory(HfsVolume volume)
+    {
+        await using var output = new MemoryStream();
+        await HfsVolumeWriter.WriteToAsync(volume, output);
     }
 
     private static async Task<HfsCatalogSnapshot> ReadCatalog(string dmgPath)

--- a/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
+++ b/test/DotnetPackaging.Dmg.Tests/DmgHfsBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using System.Text;
 using CSharpFunctionalExtensions;
 using DotnetPackaging.Dmg;
+using DotnetPackaging.Dmg.Hfs.Files;
 using DotnetPackaging.Dmg.Verification;
 using DotnetPackaging.Formats.Dmg.Udif;
 using FluentAssertions;
@@ -469,6 +470,61 @@ public class DmgHfsBuilderTests
     }
 
     [Fact]
+    public async Task BuildVolume_ShouldPreserveSourceFilesAsLazyFileBackedByteSources()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+
+        var payloadPath = Path.Combine(publish, "payload.bin");
+        await File.WriteAllBytesAsync(payloadPath, "original payload"u8.ToArray());
+
+        var volume = await DmgHfsBuilder.BuildVolume(publish, "Lazy Payload", includeDefaultLayout: false);
+        await File.WriteAllBytesAsync(payloadPath, "updated payload!"u8.ToArray());
+
+        var file = FindFile(volume.Root, "payload.bin");
+        file.Size.Should().Be(new FileInfo(payloadPath).Length);
+        file.Content.KnownLength().Value.Should().Be(new FileInfo(payloadPath).Length);
+        var content = await file.Content.ReadAll();
+        content.Value.Should().Equal("updated payload!"u8.ToArray(), "source bytes should not be captured while building the HFS model");
+    }
+
+    [Fact]
+    public async Task BuildVolume_ShouldPreserveCustomDmgAdornmentsAsLazyFileBackedByteSources()
+    {
+        using var tempRoot = new TempDir();
+        var publish = Path.Combine(tempRoot.Path, "publish");
+        Directory.CreateDirectory(publish);
+        await File.WriteAllTextAsync(Path.Combine(publish, "App"), "exe");
+
+        var dsStorePath = Path.Combine(publish, ".DS_Store");
+        var volumeIconPath = Path.Combine(publish, ".VolumeIcon.icns");
+        var background = Path.Combine(publish, ".background");
+        Directory.CreateDirectory(background);
+        var backgroundPath = Path.Combine(background, "Custom.bin");
+
+        var dsStoreOriginal = Enumerable.Repeat((byte)0x11, 16).ToArray();
+        var volumeIconOriginal = Enumerable.Repeat((byte)0x22, 24).ToArray();
+        var backgroundOriginal = Enumerable.Repeat((byte)0x33, 32).ToArray();
+        await File.WriteAllBytesAsync(dsStorePath, dsStoreOriginal);
+        await File.WriteAllBytesAsync(volumeIconPath, volumeIconOriginal);
+        await File.WriteAllBytesAsync(backgroundPath, backgroundOriginal);
+
+        var volume = await DmgHfsBuilder.BuildVolume(publish, "Custom", includeDefaultLayout: false);
+
+        var dsStoreUpdated = Enumerable.Repeat((byte)0x44, dsStoreOriginal.Length).ToArray();
+        var volumeIconUpdated = Enumerable.Repeat((byte)0x55, volumeIconOriginal.Length).ToArray();
+        var backgroundUpdated = Enumerable.Repeat((byte)0x66, backgroundOriginal.Length).ToArray();
+        await File.WriteAllBytesAsync(dsStorePath, dsStoreUpdated);
+        await File.WriteAllBytesAsync(volumeIconPath, volumeIconUpdated);
+        await File.WriteAllBytesAsync(backgroundPath, backgroundUpdated);
+
+        await AssertFileBackedContent(volume.Root, ".DS_Store", dsStoreUpdated);
+        await AssertFileBackedContent(volume.Root, ".VolumeIcon.icns", volumeIconUpdated);
+        await AssertFileBackedContent(volume.Root, ".background/Custom.bin", backgroundUpdated);
+    }
+
+    [Fact]
     public async Task HfsPlus_header_has_correct_version()
     {
         using var tempRoot = new TempDir();
@@ -670,5 +726,77 @@ public class DmgHfsBuilderTests
     private static int ReadNodeRecordOffset(ReadOnlySpan<byte> node, int nodeSize, int recordIndex)
     {
         return BinaryPrimitives.ReadUInt16BigEndian(node.Slice(nodeSize - 2 - recordIndex * 2, 2));
+    }
+
+    private static async Task AssertFileBackedContent(HfsDirectory directory, string path, byte[] expectedContent)
+    {
+        var file = FindFile(directory, path);
+        file.Size.Should().Be(expectedContent.Length);
+        file.Content.KnownLength().Value.Should().Be(expectedContent.Length);
+
+        var content = await file.Content.ReadAll();
+        content.Value.Should().Equal(expectedContent, $"source bytes for {path} should not be captured while building the HFS model");
+    }
+
+    private static HfsFile FindFile(HfsDirectory directory, string path)
+    {
+        var current = directory;
+        var parts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var child = current.Children.SingleOrDefault(x => x.Name == parts[i]);
+            if (child == null)
+            {
+                break;
+            }
+
+            if (i == parts.Length - 1 && child is HfsFile file)
+            {
+                return file;
+            }
+
+            if (child is not HfsDirectory subDirectory)
+            {
+                break;
+            }
+
+            current = subDirectory;
+        }
+
+        return FindFileByName(directory, path);
+    }
+
+    private static HfsFile FindFileByName(HfsDirectory directory, string name)
+    {
+        var found = FindFileByNameOrNull(directory, name);
+        if (found is not null)
+        {
+            return found;
+        }
+
+        throw new InvalidOperationException($"File '{name}' was not found.");
+    }
+
+    private static HfsFile? FindFileByNameOrNull(HfsDirectory directory, string name)
+    {
+        foreach (var child in directory.Children)
+        {
+            switch (child)
+            {
+                case HfsFile file when file.Name == name:
+                    return file;
+                case HfsDirectory subDirectory:
+                    var found = FindFileByNameOrNull(subDirectory, name);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+
+                    break;
+            }
+        }
+
+        return null;
     }
 }

--- a/test/DotnetPackaging.Hfs.Tests/HfsVolumeTests.cs
+++ b/test/DotnetPackaging.Hfs.Tests/HfsVolumeTests.cs
@@ -231,6 +231,49 @@ public class HfsVolumeTests
         output.ReadUInt16BigEndian(1024).Should().Be(0x482B);
     }
 
+    [Fact]
+    public async Task HfsVolumeWriter_ShouldRejectSourceOverrunBeforeWritingOverflowBytes()
+    {
+        var overflowMarker = new byte[] { 0xFA, 0xFB, 0xFC, 0xFD };
+        var source = new TrackingByteSource(["data"u8.ToArray(), overflowMarker]);
+        var volume = HfsVolumeBuilder.Create("Test")
+            .AddFile("payload.bin", source, 4)
+            .Build();
+        await using var output = new TrackingSeekableStream();
+
+        var act = async () => await HfsVolumeWriter.WriteToAsync(volume, output);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*payload.bin*Declared size: 4 bytes*emitted bytes: 8 bytes*written bytes: 4 bytes*");
+        output.ContainsSequence(overflowMarker).Should().BeFalse("overflow bytes must be rejected before they reach the HFS output stream");
+    }
+
+    [Fact]
+    public async Task HfsVolumeWriter_ShouldRejectSourceUnderrunAfterCompletion()
+    {
+        var source = new TrackingByteSource(["abc"u8.ToArray()]);
+        var volume = HfsVolumeBuilder.Create("Test")
+            .AddFile("payload.bin", source, 5)
+            .Build();
+
+        var act = async () => await HfsVolumeWriter.WriteToAsync(volume, new MemoryStream());
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*payload.bin*Declared size: 5 bytes*emitted/written bytes: 3 bytes*");
+    }
+
+    [Fact]
+    public void HfsDirectory_ShouldRejectNegativeFileSize()
+    {
+        var source = ByteSource.FromBytes("payload"u8.ToArray());
+        var builder = HfsVolumeBuilder.Create("Test");
+
+        var act = () => builder.AddFile("payload.bin", source, -1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*payload.bin*negative size*");
+    }
+
     private sealed class TrackingByteSource(byte[][] chunks) : IByteSource
     {
         public int Subscriptions { get; private set; }
@@ -328,6 +371,34 @@ public class HfsVolumeTests
             buffer[0] = bytes.GetValueOrDefault(offset);
             buffer[1] = bytes.GetValueOrDefault(offset + 1);
             return BinaryPrimitives.ReadUInt16BigEndian(buffer);
+        }
+
+        public bool ContainsSequence(byte[] sequence)
+        {
+            if (sequence.Length == 0)
+            {
+                return true;
+            }
+
+            for (var offset = 0L; offset <= Length - sequence.Length; offset++)
+            {
+                var matches = true;
+                for (var i = 0; i < sequence.Length; i++)
+                {
+                    if (bytes.GetValueOrDefault(offset + i) != sequence[i])
+                    {
+                        matches = false;
+                        break;
+                    }
+                }
+
+                if (matches)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/test/DotnetPackaging.Hfs.Tests/HfsVolumeTests.cs
+++ b/test/DotnetPackaging.Hfs.Tests/HfsVolumeTests.cs
@@ -1,7 +1,9 @@
 using System.Buffers.Binary;
+using System.Reactive.Linq;
 using DotnetPackaging.Dmg.Hfs.Builder;
 using FluentAssertions;
 using Xunit;
+using Zafiro.DivineBytes;
 
 namespace DotnetPackaging.Hfs.Tests;
 
@@ -207,5 +209,125 @@ public class HfsVolumeTests
         var usedBlocks = totalBlocks - freeBlocks;
         usedBlocks.Should().BeGreaterThan(0);
         usedBlocks.Should().BeLessThan(totalBlocks);
+    }
+
+    [Fact]
+    public async Task HfsVolumeWriter_ShouldWriteKnownLengthByteSourcesToSeekableStreamWithoutFullVolumeBuffer()
+    {
+        var payload = Enumerable.Range(0, 16)
+            .Select(index => Enumerable.Repeat((byte)index, 4096).ToArray())
+            .ToArray();
+        var source = new TrackingByteSource(payload);
+        var volume = HfsVolumeBuilder.Create("Test")
+            .AddFile("payload.bin", source, source.Length.Value)
+            .Build();
+        await using var output = new TrackingSeekableStream();
+
+        await HfsVolumeWriter.WriteToAsync(volume, output);
+
+        output.Length.Should().BeGreaterThan(payload.Sum(chunk => chunk.Length));
+        output.MaxWriteSize.Should().BeLessThan(payload.Sum(chunk => chunk.Length), "file payload chunks should be streamed instead of writing one full volume buffer");
+        source.Subscriptions.Should().Be(1);
+        output.ReadUInt16BigEndian(1024).Should().Be(0x482B);
+    }
+
+    private sealed class TrackingByteSource(byte[][] chunks) : IByteSource
+    {
+        public int Subscriptions { get; private set; }
+
+        public IObservable<byte[]> Bytes => Observable.Defer(() =>
+        {
+            Subscriptions++;
+            return chunks.ToObservable();
+        });
+
+        public CSharpFunctionalExtensions.Maybe<long> Length { get; } = CSharpFunctionalExtensions.Maybe.From(chunks.Sum(chunk => (long)chunk.Length));
+
+        public IDisposable Subscribe(IObserver<byte[]> observer) => Bytes.Subscribe(observer);
+    }
+
+    private sealed class TrackingSeekableStream : Stream
+    {
+        private readonly Dictionary<long, byte> bytes = new();
+        private long position;
+        private long length;
+
+        public int MaxWriteSize { get; private set; }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => true;
+        public override long Length => length;
+
+        public override long Position
+        {
+            get => position;
+            set => position = value;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = 0;
+            while (read < count && position < Length)
+            {
+                buffer[offset + read] = bytes.GetValueOrDefault(position);
+                position++;
+                read++;
+            }
+
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            position = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => position + offset,
+                SeekOrigin.End => Length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, null)
+            };
+
+            return position;
+        }
+
+        public override void SetLength(long value)
+        {
+            length = value;
+            if (position > value)
+            {
+                position = value;
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            MaxWriteSize = Math.Max(MaxWriteSize, count);
+
+            for (var i = 0; i < count; i++)
+            {
+                var value = buffer[offset + i];
+                if (value != 0)
+                {
+                    bytes[position] = value;
+                }
+
+                position++;
+            }
+
+            length = Math.Max(length, position);
+        }
+
+        public ushort ReadUInt16BigEndian(long offset)
+        {
+            Span<byte> buffer = stackalloc byte[2];
+            buffer[0] = bytes.GetValueOrDefault(offset);
+            buffer[1] = bytes.GetValueOrDefault(offset + 1);
+            return BinaryPrimitives.ReadUInt16BigEndian(buffer);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- preserve DMG source files as file-backed `IByteSource` entries instead of reading them into byte arrays while building the HFS model
- add a seekable stream HFS writer and keep `WriteToBytes` only as the small in-memory compatibility path
- write HFS to a temporary file and stream UDIF directly to the final DMG output file
- enforce declared HFS file sizes so file-backed sources cannot overrun or underrun their cheap `IByteSource.Length` metadata

Fixes #178

## Validation
- `dotnet test test/DotnetPackaging.Hfs.Tests/DotnetPackaging.Hfs.Tests.csproj`
- `dotnet test test/DotnetPackaging.Dmg.Tests/DotnetPackaging.Dmg.Tests.csproj`
- `dotnet build src/DotnetPackaging.Dmg/DotnetPackaging.Dmg.csproj --no-restore`
- `git diff --check`
- Azure Pipelines `SuperJMN.DotnetPackaging` build 6950: passed
